### PR TITLE
Addition of dace:cpu orchestrated versions of unit tests in workflow and overrides for near-zero errors

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,8 +1,5 @@
 name: "Translate test"
-on:
-  push:
-  pull_request:
-      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+on: [push, pull_request]
 
 jobs:
   all:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -45,7 +45,7 @@ jobs:
           run: |
             export FV3_DACEMODE=BuildAndRun
             pytest \
-              -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
+              -vvv -x -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
               --backend=dace:cpu \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -33,7 +33,7 @@ jobs:
             wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_baroclinic.physics.tar.gz
             tar -xzvf 8.1.3_c12_6ranks_baroclinic.physics.tar.gz
             cd -
-        - name: Translate Test numpy
+        - name: Numpy Translate Test
           run: |
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
@@ -41,7 +41,7 @@ jobs:
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint
 
-        - name: Translate Test dace:cpu
+        - name: Orchestrated dace:cpu Translate Test
           run: |
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,5 +1,6 @@
 name: "Translate test"
 on:
+  push:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
@@ -32,10 +33,18 @@ jobs:
             wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_baroclinic.physics.tar.gz
             tar -xzvf 8.1.3_c12_6ranks_baroclinic.physics.tar.gz
             cd -
-        - name: Translate Tests
+        - name: Translate Test numpy
           run: |
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
               --backend=numpy \
+              --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
+              ./tests/savepoint
+
+        - name: Translate Test dace:cpu
+          run: |
+            pytest \
+              -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
+              --backend=dace:cpu \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -44,6 +44,10 @@ jobs:
         - name: Orchestrated dace:cpu Translate Test
           run: |
             export FV3_DACEMODE=BuildAndRun
+            export PACE_FLOAT_PRECISION=64
+            export PACE_TEST_N_THRESHOLD_SAMPLES=0
+            export OMP_NUM_THREADS=10
+            export PACE_LOGLEVEL=Debug
             pytest \
               -vvv -x -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
               --backend=dace:cpu \

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,5 +1,8 @@
 name: "Translate test"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
   all:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -43,6 +43,7 @@ jobs:
 
         - name: Orchestrated dace:cpu Translate Test
           run: |
+            export FV3_DACEMODE=BuildAndRun
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_baroclinic/physics \
               --backend=dace:cpu \

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8.12]
+        python: [3.8.12, 3.11.7]
     steps:
         - name: Checkout repository
           uses: actions/checkout@v3.5.2

--- a/pySHiELD/stencils/microphysics.py
+++ b/pySHiELD/stencils/microphysics.py
@@ -1510,9 +1510,9 @@ def fields_update(
         # to dry mixing ratios
         omq = dp1 / dp0
         qv_dt = qv_dt + rdt * (qvz - qv0) * omq
-        ql_dt = ql_dt + rdt * (qlz - ql0) * omq # failing in dace orchestration
-        qr_dt = qr_dt + rdt * (qrz - qr0) * omq # failing in dace orchestration
-        qi_dt = qi_dt + rdt * (qiz - qi0) * omq # failing in dace orchestration
+        ql_dt = ql_dt + rdt * (qlz - ql0) * omq
+        qr_dt = qr_dt + rdt * (qrz - qr0) * omq
+        qi_dt = qi_dt + rdt * (qiz - qi0) * omq
         qs_dt = qs_dt + rdt * (qsz - qs0) * omq
         qg_dt = qg_dt + rdt * (qgz - qg0) * omq
 

--- a/pySHiELD/stencils/microphysics.py
+++ b/pySHiELD/stencils/microphysics.py
@@ -1510,9 +1510,9 @@ def fields_update(
         # to dry mixing ratios
         omq = dp1 / dp0
         qv_dt = qv_dt + rdt * (qvz - qv0) * omq
-        ql_dt = ql_dt + rdt * (qlz - ql0) * omq
-        qr_dt = qr_dt + rdt * (qrz - qr0) * omq
-        qi_dt = qi_dt + rdt * (qiz - qi0) * omq
+        ql_dt = ql_dt + rdt * (qlz - ql0) * omq # failing in dace orchestration
+        qr_dt = qr_dt + rdt * (qrz - qr0) * omq # failing in dace orchestration
+        qi_dt = qi_dt + rdt * (qiz - qi0) * omq # failing in dace orchestration
         qs_dt = qs_dt + rdt * (qsz - qs0) * omq
         qg_dt = qg_dt + rdt * (qgz - qg0) * omq
 

--- a/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -49,3 +49,12 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
+  - backend: dace:cpu
+    max_error: 2.2e-8
+    cuda_no_fma: true
+    ignore_near_zero_errors:
+      mph_ql_dt: 1e-8
+      mph_qr_dt: 1e-9
+      mph_qg_dt: 1e-18
+      mph_udt: 1e-8
+      mph_vdt: 1e-8

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -76,3 +76,12 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
+  - backend: dace:cpu
+    max_error: 2.2e-8
+    cuda_no_fma: true
+    ignore_near_zero_errors:
+      mph_ql_dt: 1e-8
+      mph_qr_dt: 1e-9
+      mph_qg_dt: 1e-18
+      mph_udt: 1e-8
+      mph_vdt: 1e-8

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -85,3 +85,12 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
+  - backend: dace:gpu
+    max_error: 2.2e-8
+    cuda_no_fma: true
+    ignore_near_zero_errors:
+      mph_ql_dt: 1e-8
+      mph_qr_dt: 1e-9
+      mph_qg_dt: 1e-18
+      mph_udt: 1e-8
+      mph_vdt: 1e-8


### PR DESCRIPTION
**Description**
Addition of `dace:cpu` orchestrated versions of unit tests in workflow to ensure orchestration completion is not effected by incoming commits.

Overrides for `dace:cpu` near zero errors added to enable tests in pySHiELD to pass under current orchestration, errors were on the order of `e-9`.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
