### PR TITLE
Hotfix: Update python version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 
 RUN apt-get update &&\
     apt install -y --no-install-recommends \


### PR DESCRIPTION
**Description**
Somehow the base Python image in PySHiELD's docker file was never updated to 3.11 and instead was using 3.8, which does not work. This fixes the that.

**How Has This Been Tested?**
Docker images were rebuilt with the correct Python version

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
