### PR TITLE
Add saturated vapor pressure calculation

### DIFF
--- a/pySHiELD/constants.py
+++ b/pySHiELD/constants.py
@@ -1,10 +1,12 @@
 from ndsl import constants
+
+
 # Driver constants
 HOCP = constants.HLV / constants.CP_AIR
 QMIN = 1.0e-10
 RAINMIN = 1.0e-13
 P850 = 85000.0
-EPSQ = 1.e-20
+EPSQ = 1.0e-20
 HSUB = constants.HLV + constants.HLF
 CZMIN = 0.0001  # cos(89.994)
 ZERO = 0.0e0
@@ -17,5 +19,5 @@ CONT = constants.CP_AIR / constants.GRAV
 CONQ = constants.HLV / constants.GRAV
 
 # Alternative Units and Precision in Physics:
-CPH2O1 = 4.218e+3 # Specific heat of water in J/kg/K
+CPH2O1 = 4.218e3  # Specific heat of water in J/kg/K
 CPH2O2 = 4.2e6

--- a/pySHiELD/constants.py
+++ b/pySHiELD/constants.py
@@ -1,0 +1,21 @@
+from ndsl import constants
+# Driver constants
+HOCP = constants.HLV / constants.CP_AIR
+QMIN = 1.0e-10
+RAINMIN = 1.0e-13
+P850 = 85000.0
+EPSQ = 1.e-20
+HSUB = constants.HLV + constants.HLF
+CZMIN = 0.0001  # cos(89.994)
+ZERO = 0.0e0
+ALBDF = 0.06
+CON_P001 = 0.001e0
+CON_DAY = 86400.0
+TF = 258.16
+TCRF = 1.0 / (constants.TICE - TF)
+CONT = constants.CP_AIR / constants.GRAV
+CONQ = constants.HLV / constants.GRAV
+
+# Alternative Units and Precision in Physics:
+CPH2O1 = 4.218e+3 # Specific heat of water in J/kg/K
+CPH2O2 = 4.2e6

--- a/pySHiELD/functions/physics_functions.py
+++ b/pySHiELD/functions/physics_functions.py
@@ -1,8 +1,8 @@
+from gt4py.cartesian import gtscript
+from gt4py.cartesian.gtscript import exp, floor, max, min
+
 import ndsl.constants as constants
 import pySHiELD.constants as physcons
-
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import exp, min, max, floor
 
 
 @gtscript.function

--- a/pySHiELD/functions/physics_functions.py
+++ b/pySHiELD/functions/physics_functions.py
@@ -1,0 +1,91 @@
+import ndsl.constants as constants
+import pySHiELD.constants as physcons
+
+from gt4py.cartesian import gtscript
+from gt4py.cartesian.gtscript import exp, min, max, floor
+
+
+@gtscript.function
+def fpvsx(t):
+    """
+    Computes saturation water vapor pressure, adapted from Fortran:
+    ! Subprogram: fpvsx        Compute saturation vapor pressure
+    !   Author: N Phillips            w/NMC2X2   Date: 30 dec 82
+    !
+    ! Abstract: Exactly compute saturation vapor pressure from temperature.
+    !   The saturation vapor pressure over either liquid and ice is computed
+    !   over liquid for temperatures above the triple point,
+    !   over ice for temperatures 20 degress below the triple point,
+    !   and a linear combination of the two for temperatures in between.
+    !   The water model assumes a perfect gas, constant specific heats
+    !   for gas, liquid and ice, and neglects the volume of the condensate.
+    !   The model does account for the variation of the latent heat
+    !   of condensation and sublimation with temperature.
+    !   The Clausius-Clapeyron equation is integrated from the triple point
+    !   to get the formula
+    !       pvsl=con_psat*(tr**xa)*exp(xb*(1.-tr))
+    !   where tr is ttp/t and other values are physical constants.
+    !   The reference for this computation is Emanuel(1994), pages 116-117.
+    !   This function should be expanded inline in the calling routine.
+    !
+    ! Program History Log:
+    !   91-05-07  Iredell             made into inlinable function
+    !   94-12-30  Iredell             exact computation
+    ! 1999-03-01  Iredell             f90 module
+    ! 2001-02-26  Iredell             ice phase
+    ! 2024-07-09  Oelbert             Python version
+    !
+    ! Usage:   pvs=fpvsx(t)
+    !
+    !   Input argument list:
+    !     t          Real(krealfp) temperature in Kelvin
+    !
+    !   Output argument list:
+    !     fpvsx      Real(krealfp) saturation vapor pressure in Pascals
+    """
+    tliq = constants.TTP
+    tice = constants.TTP - 20.0
+    dldtl = constants.CP_VAP - physcons.CPH2O1
+    heatl = constants.HLV
+    xponal = -dldtl / constants.RVGAS
+    xponbl = -dldtl / constants.RVGAS + heatl / (constants.RVGAS * constants.TTP)
+    dldti = constants.CP_VAP - constants.C_ICE_0
+    heati = constants.HLV + constants.HLF
+    xponai = -dldti / constants.RVGAS
+    xponbi = -dldti / constants.RVGAS + heati / (constants.RVGAS * constants.TTP)
+
+    tr = constants.TTP / t
+
+    fpvsx = 0.0
+    if t >= tliq:
+        fpvsx = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
+    elif t < tice:
+        fpvsx = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
+    else:
+        w = (t - tice) / (tliq - tice)
+        pvl = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
+        pvi = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
+        fpvsx = w * pvl + (1.0 - w) * pvi
+
+    return fpvsx
+
+
+@gtscript.function
+def fpvs(t):
+    xmin = 180.0
+    xmax = 330.0
+    nxpvs = 7501
+    xinc = (xmax - xmin) / (nxpvs - 1)
+    c2xpvs = 1.0 / xinc
+    c1xpvs = 1.0 - (xmin * c2xpvs)
+
+    xj = min(max(c1xpvs + c2xpvs * t, 1.0), nxpvs)
+    jx = min(xj, nxpvs - 1.0)
+    jx = floor(jx)
+
+    x = xmin + (jx * xinc)
+    xm = xmin + ((jx - 1) * xinc)
+
+    fpvs = fpvsx(xm) + (xj - jx) * (fpvsx(x) - fpvsx(xm))
+
+    return fpvs

--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa: F401
 from .translate_atmos_phy_statein import TranslateAtmosPhysDriverStatein
 from .translate_fillgfs import TranslateFillGFS
+from .translate_fpvs import TranslateFPVS
 from .translate_fv_update_phys import DycoreState, TranslateFVUpdatePhys
 from .translate_microphysics import TranslateMicroph
 from .translate_phifv3 import TranslatePhiFV3
@@ -11,4 +12,3 @@ from .translate_update_pressure_sfc_winds_phys import (
     TranslatePhysUpdatePressureSurfaceWinds,
 )
 from .translate_update_tracers_phys import TranslatePhysUpdateTracers
-from .translate_fpvs import TranslateFPVS

--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -11,3 +11,4 @@ from .translate_update_pressure_sfc_winds_phys import (
     TranslatePhysUpdatePressureSurfaceWinds,
 )
 from .translate_update_tracers_phys import TranslatePhysUpdateTracers
+from .translate_fpvs import TranslateFPVS

--- a/tests/savepoint/translate/translate_fpvs.py
+++ b/tests/savepoint/translate/translate_fpvs.py
@@ -1,0 +1,149 @@
+from ndsl import Namelist, StencilFactory
+from gt4py.cartesian.gtscript import FORWARD, computation, interval, PARALLEL
+from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+
+from ndsl.dsl.typing import (
+    FloatFieldIJ,
+    FloatField,
+)
+from pySHiELD.functions.physics_functions import fpvs, fpvsx
+from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
+import numpy as np
+
+
+def set_xval(
+    xin: FloatField,
+    xout: FloatField
+):
+    with computation(PARALLEL), interval(...):
+        xout = xin
+
+def test_fpvs(
+    temp: FloatFieldIJ,
+    fp: FloatFieldIJ,
+    fpx: FloatFieldIJ,
+):
+    with computation(FORWARD), interval(0, 1):
+        fp = fpvs(temp)
+        fpx = fpvsx(temp)
+
+def test_table(
+    xval: FloatField,
+    tab_fpvs: FloatField,
+    tab_fpvsx: FloatField,
+):
+    with computation(PARALLEL), interval(...):
+        tab_fpvs = fpvs(xval)
+        tab_fpvsx = fpvsx(xval)
+
+class FPVS:
+    def __init__(
+        self,
+        stencil_factory,
+        quantity_factory,
+        xmin,
+        xmax,
+        nxpvs,
+        xinc,
+    ):
+        print("SAVED VALUES ARE ", xmin, xmax, nxpvs, xinc)
+        # nt = ((np.arange(24 * 24 * 91) + 1) % 7501).reshape(24, 24, 91)
+        nt = np.zeros((32, 18, 91))
+        for i in range(32):
+            for j in range(18):
+                for k in range(91):
+                    nt[i, j, k] = (i + 1) * 91 + k
+        nt = nt.reshape((24, 24, 91))
+        xx = xmin + (nt - 1) * xinc
+        xx = np.pad(xx, ((3, 4), (3, 4), (0, 1)))
+        self._x = quantity_factory.from_array(
+            xx,
+            [X_DIM, Y_DIM, Z_DIM],
+            units="unknown",
+        )
+        grid_indexing = stencil_factory.grid_indexing
+
+        self._set_xval = stencil_factory.from_origin_domain(
+            set_xval,
+            origin=grid_indexing.origin_compute(),
+            domain=grid_indexing.domain_compute(),
+        )
+
+        self._test_fpvs = stencil_factory.from_origin_domain(
+            test_fpvs,
+            origin=grid_indexing.origin_compute(),
+            domain=grid_indexing.domain_compute(),
+        )
+        self._test_table = stencil_factory.from_origin_domain(
+            test_table,
+            origin=grid_indexing.origin_compute(),
+            domain=grid_indexing.domain_compute(),
+        )
+
+    def __call__(
+        self,
+        temp: FloatFieldIJ,
+        fp: FloatFieldIJ,
+        fpx: FloatFieldIJ,
+        xval: FloatField,
+        tab_fpvs: FloatField,
+        tab_fpvsx: FloatField,
+    ):
+        self._set_xval(
+            self._x,
+            xval,
+        )
+        self._test_fpvs(
+            temp,
+            fp,
+            fpx
+        )
+        self._test_table(
+            xval,
+            tab_fpvs,
+            tab_fpvsx
+        )
+
+class TranslateFPVS(TranslatePhysicsFortranData2Py):
+    def __init__(
+        self,
+        grid,
+        namelist: Namelist,
+        stencil_factory: StencilFactory,
+    ):
+        super().__init__(grid, namelist, stencil_factory)
+        self.in_vars["data_vars"] = {
+            "temp": {"shield": True},
+            "tab_fpvsx": {"shield": True},
+            "tab_fpvs": {"shield": True},
+            "xval": {"shield": True},
+            "fp": {"shield": True},
+            "fpx": {"shield": True},
+        }
+        self.in_vars["parameters"] = [
+            "xmin",
+            "xmax",
+            "nxpvs",
+            "xinc",
+        ]
+        self.out_vars = {
+            "tab_fpvsx": {"shield": True},
+            "tab_fpvs": {"shield": True},
+            "xval": {"shield": True},
+            "fp": {"shield": True},
+            "fpx": {"shield": True},
+        }
+        self.stencil_factory = stencil_factory
+
+    def compute(self, inputs):
+        self.make_storage_data_input_vars(inputs)
+        self.compute_func = FPVS(
+            self.stencil_factory,
+            quantity_factory=self.grid.quantity_factory,
+            xmin=inputs.pop("xmin"),
+            xmax=inputs.pop("xmax"),
+            nxpvs=inputs.pop("nxpvs"),
+            xinc=inputs.pop("xinc"),
+        )
+        self.compute_func(**inputs)
+        return self.slice_output(inputs)

--- a/tests/savepoint/translate/translate_fpvs.py
+++ b/tests/savepoint/translate/translate_fpvs.py
@@ -1,22 +1,17 @@
-from ndsl import Namelist, StencilFactory
-from gt4py.cartesian.gtscript import FORWARD, computation, interval, PARALLEL
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+import numpy as np
+from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, interval
 
-from ndsl.dsl.typing import (
-    FloatFieldIJ,
-    FloatField,
-)
+from ndsl import Namelist, StencilFactory
+from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from pySHiELD.functions.physics_functions import fpvs, fpvsx
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
-import numpy as np
 
 
-def set_xval(
-    xin: FloatField,
-    xout: FloatField
-):
+def set_xval(xin: FloatField, xout: FloatField):
     with computation(PARALLEL), interval(...):
         xout = xin
+
 
 def test_fpvs(
     temp: FloatFieldIJ,
@@ -27,6 +22,7 @@ def test_fpvs(
         fp = fpvs(temp)
         fpx = fpvsx(temp)
 
+
 def test_table(
     xval: FloatField,
     tab_fpvs: FloatField,
@@ -35,6 +31,7 @@ def test_table(
     with computation(PARALLEL), interval(...):
         tab_fpvs = fpvs(xval)
         tab_fpvsx = fpvsx(xval)
+
 
 class FPVS:
     def __init__(
@@ -93,16 +90,9 @@ class FPVS:
             self._x,
             xval,
         )
-        self._test_fpvs(
-            temp,
-            fp,
-            fpx
-        )
-        self._test_table(
-            xval,
-            tab_fpvs,
-            tab_fpvsx
-        )
+        self._test_fpvs(temp, fp, fpx)
+        self._test_table(xval, tab_fpvs, tab_fpvsx)
+
 
 class TranslateFPVS(TranslatePhysicsFortranData2Py):
     def __init__(


### PR DESCRIPTION
**Description**
This PR adds a two functions to calculate saturation water vapor pressure for a given temperature: fpvsx directly calculates pressures, while fpvs replicates the results from the lookup tables used by the Fortran code (important for model validation). A translate test is included.

**How Has This Been Tested?**
The Lookup table calculation was serialized as part of testing the the sfc_ocean port, and results were validated.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
