### PR TITLE
Removed Direct GT4Py Imports

### DIFF
--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -84,8 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gt4py.cartesian.gtscript as gtscript\n",
-    "from gt4py.cartesian.gtscript import PARALLEL, computation, interval\n",
+    "from ndsl.dsl.gt4py import computation, interval\n",
     "\n",
     "from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ\n",
     "from ndsl import (\n",

--- a/pySHiELD/functions/microphysics_funcs.py
+++ b/pySHiELD/functions/microphysics_funcs.py
@@ -1,6 +1,7 @@
-from ndsl.dsl.gt4py import function, exp, log, sqrt
-
 import ndsl.constants as constants
+from ndsl.dsl.gt4py import exp
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import log, sqrt
 
 
 # Marshall-Palmer constants ###
@@ -41,7 +42,7 @@ QRMIN = 1.0e-8  # Minimum value for rain water
 QVMIN = 1.0e-20  # Minimum value for water vapor (treated as zero)
 
 
-@function
+@gtfunction
 def dim(x, y):
     diff = x - y
 
@@ -49,7 +50,7 @@ def dim(x, y):
 
 
 # Compute the saturated specific humidity
-@function
+@gtfunction
 def wqs1(ta, den):
     return (
         constants.E00
@@ -64,7 +65,7 @@ def wqs1(ta, den):
 
 
 # Compute saturated specific humidity and its gradient
-@function
+@gtfunction
 def wqs2(ta, den):
     tmp = wqs1(ta, den)
 
@@ -72,7 +73,7 @@ def wqs2(ta, den):
 
 
 # Compute the saturated specific humidity
-@function
+@gtfunction
 def iqs1(ta, den):
     if ta < constants.TICE:
         # Over ice between -160 degrees Celsius and 0 degrees Celsius
@@ -111,7 +112,7 @@ def iqs1(ta, den):
 
 
 # Compute the gradient of saturated specific humidity
-@function
+@gtfunction
 def iqs2(ta, den):
     tmp = iqs1(ta, den)
 
@@ -145,7 +146,7 @@ def iqs2(ta, den):
 
 
 # Accretion function
-@function
+@gtfunction
 def acr3d(v1, v2, q1, q2, c, cac_ik, cac_i1k, cac_i2k, rho):
     t1 = sqrt(q1 * rho)
     s1 = sqrt(q2 * rho)
@@ -162,24 +163,24 @@ def acr3d(v1, v2, q1, q2, c, cac_ik, cac_i1k, cac_i2k, rho):
 
 # Melting of snow function (psacw and psacr must be calc before smlt is
 # called)
-@function
+@gtfunction
 def smlt(tc, dqs, qsrho, psacw, psacr, c_0, c_1, c_2, c_3, c_4, rho, rhofac):
     return (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qsrho) + c_3 * qsrho**0.65625 * sqrt(rhofac)
+        c_2 * sqrt(qsrho) + c_3 * qsrho ** 0.65625 * sqrt(rhofac)
     ) + c_4 * tc * (psacw + psacr)
 
 
 # Melting of graupel function (pgacw and pgacr must be calc before gmlt
 # is called)
-@function
+@gtfunction
 def gmlt(tc, dqs, qgrho, pgacw, pgacr, c_0, c_1, c_2, c_3, c_4, rho):
     return (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qgrho) + c_3 * qgrho**0.6875 / rho**0.25
+        c_2 * sqrt(qgrho) + c_3 * qgrho ** 0.6875 / rho ** 0.25
     ) + c_4 * tc * (pgacw + pgacr)
 
 
 # Evaporation of rain
-@function
+@gtfunction
 def revap_racc(
     dt,
     c_air,
@@ -265,7 +266,7 @@ def revap_racc(
 
 
 # Calculate the vertical fall speed
-@function
+@gtfunction
 def fall_speed(log_10, qg, qi, ql, qs, tk, den):
     from __externals__ import (
         const_vg,
@@ -340,7 +341,7 @@ def fall_speed(log_10, qg, qi, ql, qs, tk, den):
     return vtg, vti, vts
 
 
-@function
+@gtfunction
 def compute_rain_fspeed(no_fall, qrz, den):
     from __externals__ import const_vr, vr_fac, vr_max
 
@@ -371,7 +372,7 @@ def compute_rain_fspeed(no_fall, qrz, den):
     return vtrz, r1
 
 
-@function
+@gtfunction
 def autoconv_no_subgrid_var(
     use_ccn, fac_rc, t_wfr, so3, dt_rain, qlz, qrz, tz, den, ccn, c_praut
 ):
@@ -396,7 +397,7 @@ def autoconv_no_subgrid_var(
     return qlz, qrz
 
 
-@function
+@gtfunction
 def autoconv_subgrid_var(
     use_ccn, fac_rc, t_wfr, so3, dt_rain, qlz, qrz, tz, den, ccn, c_praut, dl
 ):
@@ -427,7 +428,7 @@ def autoconv_subgrid_var(
     return qlz, qrz
 
 
-@function
+@gtfunction
 def subgrid_z_proc(
     c_air,
     c_vap,
@@ -629,7 +630,7 @@ def subgrid_z_proc(
                                 qsi
                                 * den
                                 * constants.LAT2
-                                / (0.0243 * constants.RVGAS * tz**2)
+                                / (0.0243 * constants.RVGAS * tz ** 2)
                                 + 4.42478e4
                             )
                         )
@@ -849,7 +850,7 @@ def subgrid_z_proc(
     return qaz, qgz, qiz, qlz, qrz, qsz, qvz, tz
 
 
-@function
+@gtfunction
 def icloud_main(
     c_air,
     c_vap,

--- a/pySHiELD/functions/microphysics_funcs.py
+++ b/pySHiELD/functions/microphysics_funcs.py
@@ -1,5 +1,4 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import exp, log, sqrt
+from ndsl.dsl.gt4py import function, exp, log, sqrt
 
 import ndsl.constants as constants
 
@@ -42,7 +41,7 @@ QRMIN = 1.0e-8  # Minimum value for rain water
 QVMIN = 1.0e-20  # Minimum value for water vapor (treated as zero)
 
 
-@gtscript.function
+@function
 def dim(x, y):
     diff = x - y
 
@@ -50,7 +49,7 @@ def dim(x, y):
 
 
 # Compute the saturated specific humidity
-@gtscript.function
+@function
 def wqs1(ta, den):
     return (
         constants.E00
@@ -65,7 +64,7 @@ def wqs1(ta, den):
 
 
 # Compute saturated specific humidity and its gradient
-@gtscript.function
+@function
 def wqs2(ta, den):
     tmp = wqs1(ta, den)
 
@@ -73,7 +72,7 @@ def wqs2(ta, den):
 
 
 # Compute the saturated specific humidity
-@gtscript.function
+@function
 def iqs1(ta, den):
     if ta < constants.TICE:
         # Over ice between -160 degrees Celsius and 0 degrees Celsius
@@ -112,7 +111,7 @@ def iqs1(ta, den):
 
 
 # Compute the gradient of saturated specific humidity
-@gtscript.function
+@function
 def iqs2(ta, den):
     tmp = iqs1(ta, den)
 
@@ -146,7 +145,7 @@ def iqs2(ta, den):
 
 
 # Accretion function
-@gtscript.function
+@function
 def acr3d(v1, v2, q1, q2, c, cac_ik, cac_i1k, cac_i2k, rho):
     t1 = sqrt(q1 * rho)
     s1 = sqrt(q2 * rho)
@@ -163,24 +162,24 @@ def acr3d(v1, v2, q1, q2, c, cac_ik, cac_i1k, cac_i2k, rho):
 
 # Melting of snow function (psacw and psacr must be calc before smlt is
 # called)
-@gtscript.function
+@function
 def smlt(tc, dqs, qsrho, psacw, psacr, c_0, c_1, c_2, c_3, c_4, rho, rhofac):
     return (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qsrho) + c_3 * qsrho ** 0.65625 * sqrt(rhofac)
+        c_2 * sqrt(qsrho) + c_3 * qsrho**0.65625 * sqrt(rhofac)
     ) + c_4 * tc * (psacw + psacr)
 
 
 # Melting of graupel function (pgacw and pgacr must be calc before gmlt
 # is called)
-@gtscript.function
+@function
 def gmlt(tc, dqs, qgrho, pgacw, pgacr, c_0, c_1, c_2, c_3, c_4, rho):
     return (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qgrho) + c_3 * qgrho ** 0.6875 / rho ** 0.25
+        c_2 * sqrt(qgrho) + c_3 * qgrho**0.6875 / rho**0.25
     ) + c_4 * tc * (pgacw + pgacr)
 
 
 # Evaporation of rain
-@gtscript.function
+@function
 def revap_racc(
     dt,
     c_air,
@@ -266,7 +265,7 @@ def revap_racc(
 
 
 # Calculate the vertical fall speed
-@gtscript.function
+@function
 def fall_speed(log_10, qg, qi, ql, qs, tk, den):
     from __externals__ import (
         const_vg,
@@ -341,7 +340,7 @@ def fall_speed(log_10, qg, qi, ql, qs, tk, den):
     return vtg, vti, vts
 
 
-@gtscript.function
+@function
 def compute_rain_fspeed(no_fall, qrz, den):
     from __externals__ import const_vr, vr_fac, vr_max
 
@@ -372,7 +371,7 @@ def compute_rain_fspeed(no_fall, qrz, den):
     return vtrz, r1
 
 
-@gtscript.function
+@function
 def autoconv_no_subgrid_var(
     use_ccn, fac_rc, t_wfr, so3, dt_rain, qlz, qrz, tz, den, ccn, c_praut
 ):
@@ -397,7 +396,7 @@ def autoconv_no_subgrid_var(
     return qlz, qrz
 
 
-@gtscript.function
+@function
 def autoconv_subgrid_var(
     use_ccn, fac_rc, t_wfr, so3, dt_rain, qlz, qrz, tz, den, ccn, c_praut, dl
 ):
@@ -428,7 +427,7 @@ def autoconv_subgrid_var(
     return qlz, qrz
 
 
-@gtscript.function
+@function
 def subgrid_z_proc(
     c_air,
     c_vap,
@@ -630,7 +629,7 @@ def subgrid_z_proc(
                                 qsi
                                 * den
                                 * constants.LAT2
-                                / (0.0243 * constants.RVGAS * tz ** 2)
+                                / (0.0243 * constants.RVGAS * tz**2)
                                 + 4.42478e4
                             )
                         )
@@ -850,7 +849,7 @@ def subgrid_z_proc(
     return qaz, qgz, qiz, qlz, qrz, qsz, qvz, tz
 
 
-@gtscript.function
+@function
 def icloud_main(
     c_air,
     c_vap,

--- a/pySHiELD/functions/physics_functions.py
+++ b/pySHiELD/functions/physics_functions.py
@@ -1,11 +1,10 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import exp, floor, max, min
+from ndsl.dsl.gt4py import exp, floor, max, min, function
 
 import ndsl.constants as constants
 import pySHiELD.constants as physcons
 
 
-@gtscript.function
+@function
 def fpvsx(t):
     """
     Computes saturation water vapor pressure, adapted from Fortran:
@@ -58,19 +57,19 @@ def fpvsx(t):
 
     fpvsx = 0.0
     if t >= tliq:
-        fpvsx = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
+        fpvsx = constants.PSAT * (tr**xponal) * exp(xponbl * (1.0 - tr))
     elif t < tice:
-        fpvsx = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
+        fpvsx = constants.PSAT * (tr**xponai) * exp(xponbi * (1.0 - tr))
     else:
         w = (t - tice) / (tliq - tice)
-        pvl = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
-        pvi = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
+        pvl = constants.PSAT * (tr**xponal) * exp(xponbl * (1.0 - tr))
+        pvi = constants.PSAT * (tr**xponai) * exp(xponbi * (1.0 - tr))
         fpvsx = w * pvl + (1.0 - w) * pvi
 
     return fpvsx
 
 
-@gtscript.function
+@function
 def fpvs(t):
     xmin = 180.0
     xmax = 330.0

--- a/pySHiELD/functions/physics_functions.py
+++ b/pySHiELD/functions/physics_functions.py
@@ -1,10 +1,11 @@
-from ndsl.dsl.gt4py import exp, floor, max, min, function
-
 import ndsl.constants as constants
 import pySHiELD.constants as physcons
+from ndsl.dsl.gt4py import exp, floor
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import max, min
 
 
-@function
+@gtfunction
 def fpvsx(t):
     """
     Computes saturation water vapor pressure, adapted from Fortran:
@@ -57,19 +58,19 @@ def fpvsx(t):
 
     fpvsx = 0.0
     if t >= tliq:
-        fpvsx = constants.PSAT * (tr**xponal) * exp(xponbl * (1.0 - tr))
+        fpvsx = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
     elif t < tice:
-        fpvsx = constants.PSAT * (tr**xponai) * exp(xponbi * (1.0 - tr))
+        fpvsx = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
     else:
         w = (t - tice) / (tliq - tice)
-        pvl = constants.PSAT * (tr**xponal) * exp(xponbl * (1.0 - tr))
-        pvi = constants.PSAT * (tr**xponai) * exp(xponbi * (1.0 - tr))
+        pvl = constants.PSAT * (tr ** xponal) * exp(xponbl * (1.0 - tr))
+        pvi = constants.PSAT * (tr ** xponai) * exp(xponbi * (1.0 - tr))
         fpvsx = w * pvl + (1.0 - w) * pvi
 
     return fpvsx
 
 
-@function
+@gtfunction
 def fpvs(t):
     xmin = 180.0
     xmax = 330.0

--- a/pySHiELD/stencils/get_phi_fv3.py
+++ b/pySHiELD/stencils/get_phi_fv3.py
@@ -1,6 +1,5 @@
-from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation, interval
-
 from ndsl.constants import ZVIR
+from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField
 
 

--- a/pySHiELD/stencils/get_phi_fv3.py
+++ b/pySHiELD/stencils/get_phi_fv3.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import BACKWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation, interval
 
 from ndsl.constants import ZVIR
 from ndsl.dsl.typing import FloatField

--- a/pySHiELD/stencils/get_prs_fv3.py
+++ b/pySHiELD/stencils/get_prs_fv3.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 from ndsl.constants import ZVIR
 from ndsl.dsl.typing import FloatField

--- a/pySHiELD/stencils/get_prs_fv3.py
+++ b/pySHiELD/stencils/get_prs_fv3.py
@@ -1,6 +1,5 @@
-from ndsl.dsl.gt4py import PARALLEL, computation, interval
-
 from ndsl.constants import ZVIR
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField
 
 

--- a/pySHiELD/stencils/microphysics.py
+++ b/pySHiELD/stencils/microphysics.py
@@ -2,7 +2,7 @@ import copy
 import typing
 
 import numpy as np
-from gt4py.cartesian.gtscript import (
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -1824,7 +1824,7 @@ class Microphysics:
         pie = 4.0 * np.arctan(1.0)
 
         # S. Klein's formular (eq 16) from am2
-        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh ** 3
+        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh**3
 
         vdifu = 2.11e-5
         tcond = 2.36e-2
@@ -1888,7 +1888,7 @@ class Microphysics:
             / act[0] ** 0.65625
         )
         self._cssub_3 = tcond * constants.RVGAS
-        self._cssub_4 = (hlts ** 2) * vdifu
+        self._cssub_4 = (hlts**2) * vdifu
 
         self._cgsub_0 = 2.0 * pie * vdifu * tcond * constants.RVGAS * rnzg
         self._cgsub_1 = 0.78 / np.sqrt(act[5])
@@ -1902,7 +1902,7 @@ class Microphysics:
             0.31 * scm3 * gam290 * np.sqrt(self.namelist.alin / visk) / act[1] ** 0.725
         )
         self._crevp_3 = self._cssub_3
-        self._crevp_4 = hltc ** 2 * vdifu
+        self._crevp_4 = hltc**2 * vdifu
 
         self._cgfr_0 = 20.0e2 * pisq * rnzr * functions.RHOR / act[1] ** 1.75
         self._cgfr_1 = 0.66

--- a/pySHiELD/stencils/microphysics.py
+++ b/pySHiELD/stencils/microphysics.py
@@ -2,20 +2,13 @@ import copy
 import typing
 
 import numpy as np
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    interval,
-    sqrt,
-)
 
 import ndsl.constants as constants
 import pySHiELD.functions.microphysics_funcs as functions
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, Int
 from ndsl.grid import GridData
 
@@ -1824,7 +1817,7 @@ class Microphysics:
         pie = 4.0 * np.arctan(1.0)
 
         # S. Klein's formular (eq 16) from am2
-        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh**3
+        fac_rc = (4.0 / 3.0) * pie * functions.RHOR * self.namelist.rthresh ** 3
 
         vdifu = 2.11e-5
         tcond = 2.36e-2
@@ -1888,7 +1881,7 @@ class Microphysics:
             / act[0] ** 0.65625
         )
         self._cssub_3 = tcond * constants.RVGAS
-        self._cssub_4 = (hlts**2) * vdifu
+        self._cssub_4 = (hlts ** 2) * vdifu
 
         self._cgsub_0 = 2.0 * pie * vdifu * tcond * constants.RVGAS * rnzg
         self._cgsub_1 = 0.78 / np.sqrt(act[5])
@@ -1902,7 +1895,7 @@ class Microphysics:
             0.31 * scm3 * gam290 * np.sqrt(self.namelist.alin / visk) / act[1] ** 0.725
         )
         self._crevp_3 = self._cssub_3
-        self._crevp_4 = hltc**2 * vdifu
+        self._crevp_4 = hltc ** 2 * vdifu
 
         self._cgfr_0 = 20.0e2 * pisq * rnzr * functions.RHOR / act[1] ** 1.75
         self._cgfr_1 = 0.66

--- a/pySHiELD/stencils/physics.py
+++ b/pySHiELD/stencils/physics.py
@@ -1,19 +1,10 @@
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    function,
-    cos,
-    exp,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
 import pySHiELD.constants as physcons
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, cos, exp
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pySHiELD._config import PHYSICS_PACKAGES, PhysicsConfig
@@ -294,7 +285,7 @@ def prepare_microphysics(
         qa_dt = 0.0
 
 
-@function
+@gtfunction
 def forward_euler(q_t0, q_dt, dt):
     return q_t0 + q_dt * dt
 

--- a/pySHiELD/stencils/physics.py
+++ b/pySHiELD/stencils/physics.py
@@ -1,9 +1,9 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,
     computation,
+    function,
     cos,
     exp,
     interval,
@@ -294,7 +294,7 @@ def prepare_microphysics(
         qa_dt = 0.0
 
 
-@gtscript.function
+@function
 def forward_euler(q_t0, q_dt, dt):
     return q_t0 + q_dt * dt
 

--- a/pySHiELD/update/fv_update_phys.py
+++ b/pySHiELD/update/fv_update_phys.py
@@ -1,5 +1,3 @@
-from ndsl.dsl.gt4py import FORWARD, function, PARALLEL, computation, exp, interval, log
-
 import ndsl.constants as constants
 import pyFV3
 from ndsl import (
@@ -10,6 +8,9 @@ from ndsl import (
     orchestrate,
 )
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, exp
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DriverGridData, GridData
 from ndsl.stencils.c2l_ord import CubedToLatLon
@@ -18,7 +19,7 @@ from pySHiELD.update.update_dwind_phys import AGrid2DGridPhysics
 
 
 # TODO: This is the same as moist_cv.py in pyFV3, should move to integration dir
-@function
+@gtfunction
 def moist_cvm(qvapor, gz, ql, qs):
     cvm = (
         (1.0 - (qvapor + gz)) * constants.CV_AIR

--- a/pySHiELD/update/fv_update_phys.py
+++ b/pySHiELD/update/fv_update_phys.py
@@ -1,5 +1,4 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, exp, interval, log
+from ndsl.dsl.gt4py import FORWARD, function, PARALLEL, computation, exp, interval, log
 
 import ndsl.constants as constants
 import pyFV3
@@ -19,7 +18,7 @@ from pySHiELD.update.update_dwind_phys import AGrid2DGridPhysics
 
 
 # TODO: This is the same as moist_cv.py in pyFV3, should move to integration dir
-@gtscript.function
+@function
 def moist_cvm(qvapor, gz, ql, qs):
     cvm = (
         (1.0 - (qvapor + gz)) * constants.CV_AIR

--- a/pySHiELD/update/update_atmos_state.py
+++ b/pySHiELD/update/update_atmos_state.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
-
 import pyFV3
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.grid import DriverGridData, GridData
 from ndsl.typing import Communicator

--- a/pySHiELD/update/update_atmos_state.py
+++ b/pySHiELD/update/update_atmos_state.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import pyFV3
 from ndsl import QuantityFactory, StencilFactory, orchestrate

--- a/pySHiELD/update/update_dwind_phys.py
+++ b/pySHiELD/update/update_dwind_phys.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, TilePartitioner, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM

--- a/pySHiELD/update/update_dwind_phys.py
+++ b/pySHiELD/update/update_dwind_phys.py
@@ -1,7 +1,6 @@
-from ndsl.dsl.gt4py import PARALLEL, computation, interval
-
 from ndsl import QuantityFactory, StencilFactory, TilePartitioner, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldI, FloatFieldIJ
 from ndsl.grid import DriverGridData
 

--- a/tests/savepoint/translate/translate_fpvs.py
+++ b/tests/savepoint/translate/translate_fpvs.py
@@ -1,8 +1,8 @@
 import numpy as np
-from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 
 from ndsl import Namelist, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from pySHiELD.functions.physics_functions import fpvs, fpvsx
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py

--- a/tests/savepoint/translate/translate_fpvs.py
+++ b/tests/savepoint/translate/translate_fpvs.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 
 from ndsl import Namelist, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM


### PR DESCRIPTION
All references to GT4Py have been removed and replaced with imports from NDSL, bringing this repository in compliance with the changes made to NDSL [here](https://github.com/NOAA-GFDL/NDSL/pull/126).

All future references to GT4Py tools should be references via `ndsl.dsl.gt4py` instead of `gt4py.cartesian.gtscript`.