### PR TITLE
ci: Remove `PACE_TEST_N_THRESHOLD_SAMPLES` in translate test

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -84,7 +84,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pySHiELD
           export FV3_DACEMODE=BuildAndRun
           export PACE_FLOAT_PRECISION=64
-          export PACE_TEST_N_THRESHOLD_SAMPLES=0
           export OMP_NUM_THREADS=10
           export PACE_LOGLEVEL=Debug
           pytest \


### PR DESCRIPTION
**Description**

Don't set `PACE_TEST_N_THRESHOLD_SAMPLES` in translate tests anymore since the environment variable was renamed in PR https://github.com/NOAA-GFDL/NDSL/pull/134 and the default changed to match the currently configured behavior.

**How Has This Been Tested?**

By doing a self-review of the code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
