### PR TITLE
No boost dependency anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update -y && \
     libgeos-dev \
     libopenmpi3 \
     libopenmpi-dev \
-    libboost-all-dev \
     libhdf5-serial-dev \
     libffi-dev \
     netcdf-bin \


### PR DESCRIPTION
**Description**

Newer GT4Py versions come with a vendored-in version of the one boost header that they need. NDSL picked up this newer version and this PR propagates that change to PySHiELD, which now doesn't need to depend on boost headers in the `Dockerfile`. Not sure if the `Dockerfile` is still in use, but it was easy enough to just update it.

For the record: The relevant GT4Py update in NDSL was done in https://github.com/NOAA-GFDL/NDSL/pull/150.

**How Has This Been Tested?**

By doing a self-review of the proposed code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
