### PR TITLE
ci: Simplify linting workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,27 +1,23 @@
 name: "Lint"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout Pace repository
-          uses: actions/checkout@v3.5.2
+        - name: Checkout repository
+          uses: actions/checkout@v4
           with:
             submodules: 'recursive'
-        - name: Step Python 3.11.7
-          uses: actions/setup-python@v4.6.0
+
+        - name: Setup Python 3.11
+          uses: actions/setup-python@v5
           with:
-            python-version: '3.11.7'
-        - name: Install OpenMPI for gt4py
-          run: |
-            sudo apt-get install libopenmpi-dev
-        - name: Install Python packages
-          run: |
-            python -m pip install --upgrade pip setuptools wheel
-            pip install .[develop]
+            python-version: '3.11'
+
+        - name: Install pre-commit
+          run: pip install pre-commit
+
         - name: Run lint via pre-commit
-          run: |
-            pre-commit run --all-files
+          run: pre-commit run --all-files


### PR DESCRIPTION
**Description**

Linting currently takes around 3 minutes to complete where more than 2 minutes are spent installing (python) packages that aren't needed. This PR streamlines the linting workflow and should bring runtime down to under a minute.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
