### PR TITLE
Physics state initialization fix

### DIFF
--- a/pyshield/physics_state.py
+++ b/pyshield/physics_state.py
@@ -331,7 +331,7 @@ class PhysicsState:
                     _field.metadata["dims"],
                     _field.metadata["units"],
                     dtype=Float,
-                ).data
+                )
         return cls(
             **initial_arrays,
             quantity_factory=quantity_factory,


### PR DESCRIPTION
Removes a lingering `.data` tag from the `init_zeros` method in `physics_state.py`. Change results in the physics state accurately creating quantities instead of numpy arrays.