### PR TITLE
Fix: Matching `pyFV3` package specifications

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-        additional_dependencies: ["click==8.0.4"]
 
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
@@ -20,12 +19,7 @@ repos:
       - id: mypy
         name: mypy-physics
         args: ["--config-file", "pyproject.toml"]
-        additional_dependencies: [types-PyYAML]
         files: pySHiELD
-        exclude: |
-          (?x)^(
-          pySHiELD/tests/conftest.py
-          )$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -39,15 +33,6 @@ repos:
       - id: flake8
         name: flake8
         language_version: python3
-        additional_dependencies: [Flake8-pyproject]
-        exclude: |
-          (?x)^(
-          .*/__init__.py |
-          )$
-      - id: flake8
-        name: flake8 __init__.py files
-        files: "__init__.py"
-      # ignore unused import error in __init__.py files
         additional_dependencies: [Flake8-pyproject]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ source_pkgs = ["pyshield"]
 exclude = ["docs"]
 extend-ignore = ["W503", "E302", "E203", "F841"]
 max-line-length = 88
-per-file-ignores = "__init__.py: F401"
 
 [tool.isort]
 default_section = "THIRDPARTY"
@@ -87,6 +86,7 @@ sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 use_parentheses = true
 
 [tool.mypy]
+exclude = ["tests/conftest.py"]
 explicit_package_bases = true
 follow_imports = "normal"
 ignore_missing_imports = true

--- a/pyshield/__init__.py
+++ b/pyshield/__init__.py
@@ -3,7 +3,7 @@ from .physics_state import PhysicsState
 from .stencils.physics import Physics
 
 
-__all__ = list(key for key in locals().keys() if not key.startswith("_"))
+__all__ = ["PHYSICS_PACKAGES", "PhysicsConfig", "PhysicsState", "Physics"]
 __version__ = "0.2.0"
 
 """

--- a/pyshield/stencils/__init__.py
+++ b/pyshield/stencils/__init__.py
@@ -5,3 +5,5 @@ from .microphysics import Microphysics, MicrophysicsState
 Microphysics: GFS Cloud Microphysics class
 MicrophysicsState: Class containing the state for the GFS Cloud Microphysics
 """
+
+__all__ = ["Microphysics", "MicrophysicsState"]

--- a/pyshield/update/__init__.py
+++ b/pyshield/update/__init__.py
@@ -11,3 +11,10 @@ UpdateAtmosphereState: Class containing methods to apply tendencies while keepin
                        prognostic state consistent
 AGrid2DGridPhysics: Class to transform wind tendencies from the A-grid to the D grid
 """
+
+__all__ = [
+    "ApplyPhysicsToDycore",
+    "DycoreToPhysics",
+    "UpdateAtmosphereState",
+    "AGrid2DGridPhysics",
+]


### PR DESCRIPTION
**Description**
This PR amends the `pyproject.toml`, `pre-commit-config.yaml`, and `__init__` files to match the layout used in `pyFV3`. All `__init__` files now make use of the `__all__` module variable to avoid unused imports. All specifications for linting tools are now contained within `pyproject.toml`

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
