### PR TITLE
Revert "Physics state initialization fix"

### DIFF
--- a/pyshield/physics_state.py
+++ b/pyshield/physics_state.py
@@ -331,7 +331,7 @@ class PhysicsState:
                     _field.metadata["dims"],
                     _field.metadata["units"],
                     dtype=Float,
-                )
+                ).data
         return cls(
             **initial_arrays,
             quantity_factory=quantity_factory,


### PR DESCRIPTION
**Description**

Looks like `pace` tests are broken with the current version of `PySHiELD` physics. We tracked it down to the last (merge) commit. This PR reverts https://github.com/NOAA-GFDL/PySHiELD/pull/38, which brings things back into a working condition.

Initial work to fix this in pace (see https://github.com/NOAA-GFDL/pace/pull/134) didn't work out of the box.

Looks like the error crept in because of a stale/outdated CI run on the PR. Once we have the merge queue (e.g. PR #41) in place, we won't have this problem anymore.

**How Has This Been Tested?**

Running CI doesn't fail pace main tests as it does for https://github.com/NOAA-GFDL/PySHiELD/pull/41.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
