### PR TITLE
Re-appy: physics state initialization fix

### DIFF
--- a/pyshield/physics_state.py
+++ b/pyshield/physics_state.py
@@ -331,7 +331,7 @@ class PhysicsState:
                     _field.metadata["dims"],
                     _field.metadata["units"],
                     dtype=Float,
-                ).data
+                )
         return cls(
             **initial_arrays,
             quantity_factory=quantity_factory,


### PR DESCRIPTION
**Description**

This is a re-apply of PR #38, which removes a (stale) `.data` from the physics state in `init_zeros`. Needed for future work and now that https://github.com/NOAA-GFDL/pace/pull/139 has merged, we should be able to apply it without breaking pace tests.

Fixes issue #43.

**How Has This Been Tested?**

All good as long as CI (especially pace tests) are still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
