### PR TITLE
Fix: Remove `sqlite` and enforce `numpy==1.26.4` for each installation method in workflow

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -43,7 +43,6 @@ jobs:
           conda-remove-defaults: true
           auto-activate-base: false
           activate-environment: pyshield_test_env
-          shell: bash
 
       - name: Install mpi (MPICH flavor)
         shell: bash -l {0}
@@ -68,6 +67,8 @@ jobs:
           pip3 install --upgrade pip setuptools wheel
           cd ${{inputs.component_name}} && pip3 install .[test] && cd ..
           pip3 install .[ndsl,test]
+          pip install numpy==1.26.4
+          conda remove sqlite
 
       - name: external trigger Install packages for NDSL component
         shell: bash -l {0}
@@ -77,6 +78,8 @@ jobs:
           pip3 install --upgrade pip setuptools wheel
           cd ${{inputs.component_name}} && pip3 install .[test] && cd ..
           pip3 install .[pyfv3,test]
+          pip install numpy==1.26.4
+          conda remove sqlite
 
       - name: Install pySHiELD packages
         shell: bash -l {0}
@@ -84,7 +87,6 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pySHiELD
           pip install --upgrade pip setuptools wheel
-          pip install netcdf4==1.7.2
           pip install -v .[ndsl,pyfv3,test]
           pip install numpy==1.26.4
           conda remove sqlite

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -43,6 +43,7 @@ jobs:
           conda-remove-defaults: true
           auto-activate-base: false
           activate-environment: pyshield_test_env
+          shell: bash
 
       - name: Install mpi (MPICH flavor)
         shell: bash -l {0}

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -94,6 +94,16 @@ jobs:
       - name: conda list
         run: conda list
 
+      - name: whichs
+        run: |
+          which python
+          python --version
+          which pip
+          pip --version
+          which conda
+          conda --version
+          which pyrte_rrtmgp
+
       - name: Download data
         shell: bash -l {0}
         run: |

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -87,28 +87,9 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pySHiELD
           pip install --upgrade pip setuptools wheel
-          pip install -v .[ndsl,pyfv3,test]
+          pip install .[ndsl,pyfv3,test]
           pip install numpy==1.26.4
           conda remove sqlite
-
-      - name: pip list
-        shell: bash -l {0}
-        run: pip list
-
-      - name: conda list
-        shell: bash -l {0}
-        run: conda list
-
-      - name: whichs
-        shell: bash -l {0}
-        run: |
-          which python
-          python --version
-          which pip
-          pip --version
-          which conda
-          conda --version
-          which pyrte_rrtmgp
 
       - name: Download data
         shell: bash -l {0}

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -90,12 +90,15 @@ jobs:
           conda remove sqlite
 
       - name: pip list
+        shell: bash -l {0}
         run: pip list
 
       - name: conda list
+        shell: bash -l {0}
         run: conda list
 
       - name: whichs
+        shell: bash -l {0}
         run: |
           which python
           python --version

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -87,6 +87,12 @@ jobs:
           pip install numpy==1.26.4
           conda remove sqlite
 
+      - name: pip list
+        run: pip list
+
+      - name: conda list
+        run: conda list
+
       - name: Download data
         shell: bash -l {0}
         run: |

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -84,7 +84,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pySHiELD
           pip install --upgrade pip setuptools wheel
           pip install netcdf4==1.7.2
-          pip install -vv .[ndsl,pyfv3,test]
+          pip install -v .[ndsl,pyfv3,test]
           pip install numpy==1.26.4
           conda remove sqlite
 

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -83,7 +83,8 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pySHiELD
           pip install --upgrade pip setuptools wheel
-          pip install .[ndsl,pyfv3,test]
+          pip install netcdf4==1.7.2
+          pip install -vv .[ndsl,pyfv3,test]
           pip install numpy==1.26.4
           conda remove sqlite
 


### PR DESCRIPTION
**Description**
This PR ensures that `numpy==1.26.4` and `sqlite` will be removed for each installation method within the workflow

**How Has This Been Tested?**
Currently implemented unit tests

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
