### PR TITLE
Updating base container image to python:3.11-slim-bookworm to match Pace + cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim-bookworm@sha256:7cd3fa11d619688317226bc93dc59bc8966e9aec6bc2a6abb847e8ab7d656706
 
 RUN apt-get update &&\
     apt install -y --no-install-recommends \
@@ -29,10 +29,10 @@ RUN which python
 RUN pip --version
 RUN which pip
 
-COPY ./ /pySHiELD/
+COPY ./ /pyshield/
 
 # Install pySHiELD and the full dependencies
-RUN pip install -e pySHiELD[develop]
+RUN cd /pyshield && pip install -e .[dev]
 
 RUN pip install \
     matplotlib \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MakefileSHELL=/bin/bash
 CWD=$(shell pwd)
 CMD ?= bash
 DEV ?=y
-ROOT_DIR ?= /pySHiELD
+ROOT_DIR ?= /pyshield
 IMAGE_NAME ?= noaa-gfdl/pyshield
 
 NUM_RANKS ?=6


### PR DESCRIPTION
**Description**
(This is the pySHiELD version of a similar PR in pyFV3: https://github.com/NOAA-GFDL/PyFV3/pull/79)

Updating base container image to python:3.11-slim-bookworm to match Pace. The previous base container was failing to build with errors:

```
Error: Unable to locate package software-properties-common
Error: building at STEP "RUN apt-get update &&    apt install -y --no-install-recommends     software-properties-common": while running runtime: exit status 100
make: *** [Makefile:45: build] Error 100
```
Also, I added a small clean up in the Makefile to update `ROOT_DIR ?= /pyshield`. This is so `make savepoint_tests` can run through the container.

**How Has This Been Tested?**
```
#Tested on AMD box:
make build
make dev
cd pyshield
cd ../pySHiELDpython -m pytest tests/savepoint/ --data_path=test_data/8.1.3/c12_6ranks_baroclinic/physics/ --backend=numpy --threshold_overrides_file=tests/savepoint/translate/overrides/standard.yaml
exit

make safepoint_tests

# Results match expected:= 48 passed, 1 skipped, 6 xfailed, 19 warnings, 228 subtests passed in 48.54s =
```
**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)
- [ ] New check tests, if applicable, are included (not applicable)
- [ ] Targeted model if this changed was triggered by a model need/shortcoming (not applicable)