### PR TITLE
ci: only download test data if not alreay cached

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -65,7 +65,7 @@ jobs:
           lookup-only: true  # don't actually download the cache
 
       - name: Download test data (if not already cached)
-        if: steps.cache-restore.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p pySHiELD/test_data && cd pySHiELD/test_data
           wget ${{ env.TEST_DATA_URL }}


### PR DESCRIPTION
**Description**

Follow-up from https://github.com/NOAA-GFDL/PySHiELD/pull/55 to only download cache data in the create cache workflow in case we are actually building a new cache.

@fmalatino Same as issue as in pyFV3 https://github.com/NOAA-GFDL/PyFV3/pull/82. My code self-review wasn't particularly good :(

**How Has This Been Tested?**

Self-review of code.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
