### PR TITLE
tests: properly register and skip translate test for GFSPhysicsDriver

### DIFF
--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -4,6 +4,7 @@ from .translate_dcyc import TranslateRadInterp
 from .translate_fillgfs import TranslateFillGFS
 from .translate_fpvs import TranslateFPVS
 from .translate_fv_update_phys import DycoreState, TranslateFVUpdatePhys
+from .translate_gfs_physics_driver import TranslateGFSPhysicsDriver
 from .translate_microphysics import TranslateMicroph
 from .translate_phifv3 import TranslatePhiFV3
 from .translate_physics import ParallelPhysicsTranslate2Py, TranslateFortranData2Py

--- a/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -1,7 +1,7 @@
 import copy
 
 import ndsl.dsl.gt4py_utils as utils
-import ndsl.initialization as util
+from ndsl import QuantityFactory, SubtileGridSizer
 from pyshield import PHYSICS_PACKAGES, Physics, PhysicsConfig, PhysicsState
 from pyshield.update import update_atmos_state
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
@@ -117,7 +117,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             origin=self.grid_indexing.origin_compute()[0:2],
             backend=self.stencil_factory.backend,
         )
-        sizer = util.SubtileGridSizer.from_tile_params(
+        sizer = SubtileGridSizer.from_tile_params(
             nx_tile=self.namelist.npx - 1,
             ny_tile=self.namelist.npy - 1,
             nz=self.namelist.npz,
@@ -126,7 +126,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             layout=self.namelist.layout,
         )
 
-        quantity_factory = util.QuantityFactory.from_backend(
+        quantity_factory = QuantityFactory.from_backend(
             sizer, self.stencil_factory.backend
         )
         schemes = [PHYSICS_PACKAGES["GFS_microphysics"]]
@@ -150,7 +150,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             self.grid.quantity_factory,
             self.namelist,
             do_dry_convective_adjust=False,
-            dycore_only=self.namelist.dycore_only,
+            dycore_only=False,
         )
         dycore_to_physics(dycore_state=physics_state, physics_state=physics_state)
         physics._atmos_phys_driver_statein(

--- a/tests/savepoint/translate/translate_physics.py
+++ b/tests/savepoint/translate/translate_physics.py
@@ -48,6 +48,7 @@ class TranslatePhysicsFortranData2Py(TranslateFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, stencil_factory)
         self.namelist = PhysicsConfig.from_namelist(namelist)
+        self.skip_test = True
 
     def transform_physics_serialized_data(self, data, roll_zero, index_order):
         if isinstance(data, np.ndarray):

--- a/tests/savepoint/translate/translate_physics.py
+++ b/tests/savepoint/translate/translate_physics.py
@@ -48,6 +48,12 @@ class TranslatePhysicsFortranData2Py(TranslateFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, stencil_factory)
         self.namelist = PhysicsConfig.from_namelist(namelist)
+
+        # This test wasn't running (on CI) for a long time because it was misconfigured.
+        # Now it's properly configured and temporarily skipped (i.e. still not running
+        # as before). Issue https://github.com/NOAA-GFDL/PySHiELD/issues/66 exists to
+        # re-enable and fix this test. To unskip, just delete the following line (and
+        # this comment).
         self.skip_test = True
 
     def transform_physics_serialized_data(self, data, roll_zero, index_order):


### PR DESCRIPTION
**Description**

The translate test for `GFSPhysicsDriver` currently isn't properly registered. NDSL's translate test system thus automatically marks the test as `xfail` (expected failure) because it can't find the translate test class. `xfail`s are easy to oversee and don't generally raise alarm (because - after all - the test is expected to fail and it does so). `xfail` is generally used to test that missing features raise a warning. The behavior only started to show after [some typing work](https://github.com/NOAA-GFDL/NDSL/pull/258), which made things more strict.

Given the above context, this PR

- properly registers `GFSPhysicDriver` as a translate test,
- skips the `GFSPhysicsDriver` test because it's failing in numerical validation (to be unskipped with [issue #66](https://github.com/NOAA-GFDL/PySHiELD/issues/66))
- triggers a change in NDSL to not `xfail` and instead `raise` an exception if something's off with translate tests: https://github.com/NOAA-GFDL/NDSL/pull/259.

**How Has This Been Tested?**

Running translate tests locally (with the numpy backend) and on the CI (as always).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
  N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
  N/A
