### PR TITLE
ci: make "create cache" a reusable workflow

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -9,6 +9,7 @@ name: "Create GHA cache"
 # branch (which is where almost all PRs merge into).
 
 on:
+  workflow_call: # when called from a downstream repo
   push:
     branches: [develop]
 
@@ -20,6 +21,8 @@ concurrency:
 jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
+    # downstream repos have their own pre-commit environment
+    if: github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -12,10 +12,12 @@ on:
   workflow_call: # when called from a downstream repo
     inputs:
       # GHA doesn't seem to provide a simple way to detect workflow_call events
-      # so we are using an extra input
+      # so we are using an extra input (which is only available when this workflow
+      # is called from another workflow) with a default value (such that we don't
+      # have to set it every time)
       skip-pre-commit:
         type: boolean
-        default: false
+        default: true
         required: false
   push:
     branches: [develop]
@@ -29,7 +31,7 @@ jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
     # downstream repos have their own pre-commit environment
-    if: ${{inputs.skip-pre-commit}}
+    if: ${{!inputs.skip-pre-commit}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -15,7 +15,7 @@ on:
       # so we are using an extra input (which is only available when this workflow
       # is called from another workflow) with a default value (such that we don't
       # have to set it every time)
-      skip-pre-commit:
+      external-call:
         type: boolean
         default: true
         required: false
@@ -31,7 +31,7 @@ jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
     # downstream repos have their own pre-commit environment
-    if: ${{!inputs.skip-pre-commit}}
+    if: ${{ !inputs.external-call }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -12,12 +12,10 @@ on:
   workflow_call: # when called from a downstream repo
     inputs:
       # GHA doesn't seem to provide a simple way to detect workflow_call events
-      # so we are using an extra input (which is only available when this workflow
-      # is called from another workflow) with a default value (such that we don't
-      # have to set it every time)
+      # so we are using an extra input
       skip-pre-commit:
         type: boolean
-        default: true
+        default: false
         required: false
   push:
     branches: [develop]

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -29,7 +29,7 @@ jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
     # downstream repos have their own pre-commit environment
-    if: inputs.skip-pre-commit
+    if: ${{inputs.skip-pre-commit}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -10,6 +10,15 @@ name: "Create GHA cache"
 
 on:
   workflow_call: # when called from a downstream repo
+    inputs:
+      # GHA doesn't seem to provide a simple way to detect workflow_call events
+      # so we are using an extra input (which is only available when this workflow
+      # is called from another workflow) with a default value (such that we don't
+      # have to set it every time)
+      skip-pre-commit:
+        type: boolean
+        default: true
+        required: false
   push:
     branches: [develop]
 
@@ -22,7 +31,7 @@ jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
     # downstream repos have their own pre-commit environment
-    if: github.event_name != 'workflow_call'
+    if: inputs.skip-pre-commit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
**Description**

Recent (planned) downtime of NCCS portal showed a whole in our translate test data caching strategy. When we run pySHiELD tests as re-usable workflow in e.g. NDSL tests, we don't cache the translate test data. To do so, we can "upgrade" the "create cache" workflow to be re-usable such that we can call it from e.g. NDSL when we create the cache there.

GHA doesn't provide a way to detect `workflow_call` as an event (e.g. `github.event` will be `workflow_dispatch` in that case, which is the same as for a manual dispatch). We thus create an artificial input in case the workflow is called from another workflow. That way we know. The artificial input has a default value such that we don't need to set it from the calling workflow.

**How Has This Been Tested?**

Tested on my fork, e.g. https://github.com/romanc/NDSL/pull/5.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
