### PR TITLE
refactor: avoid deprecatios warnings after NDSL release

### DIFF
--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -119,7 +119,6 @@
     "    ny_tile=ny,\n",
     "    nz=nz,\n",
     "    n_halo=nhalo,\n",
-    "    extra_dim_lengths={},\n",
     "    layout=layout,\n",
     "    tile_partitioner=partitioner.tile,\n",
     "    tile_rank=cs_communicator.tile.rank,\n",

--- a/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -119,7 +119,6 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             ny_tile=self.config.npy - 1,
             nz=self.config.npz,
             n_halo=3,
-            extra_dim_lengths={},
             layout=self.config.layout,
         )
 

--- a/tests/savepoint/translate/translate_microphysics.py
+++ b/tests/savepoint/translate/translate_microphysics.py
@@ -77,7 +77,6 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             ny_tile=self.config.npy - 1,
             nz=self.config.npz,
             n_halo=3,
-            extra_dim_lengths={},
             layout=self.config.layout,
         )
 


### PR DESCRIPTION
**Description**

Change `extra_dim_lengths` -> `data_dimensions` when creating a `SubtileGridSizer`. We can remove empty dictionaries `{}` because that's now the default. Previously that default wasn't re-entrant so many places specified the option explicitly. Now there's no need anymore for this.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
