### PR TITLE
refactor: use new constructor of `QuantityFactory`

### DIFF
--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -125,7 +125,7 @@
     ")\n",
     "\n",
     "# useful for easily allocating distributed data storages (fields)\n",
-    "quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)\n",
+    "quantity_factory = QuantityFactory(sizer=sizer, backend=backend)\n",
     "\n",
     "compilation_config = CompilationConfig(backend=backend, communicator=cs_communicator)\n",
     "\n",

--- a/examples/notebook/test_rad.ipynb
+++ b/examples/notebook/test_rad.ipynb
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "aed95766-57de-4d98-bc32-13473065140f",
    "metadata": {},
    "outputs": [],
@@ -102,9 +102,7 @@
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
     ")\n",
-    "quantity_factory = QuantityFactory.from_backend(\n",
-    "    sizer, backend=\"numpy\"\n",
-    ")"
+    "quantity_factory = QuantityFactory(sizer, backend=\"numpy\")"
    ]
   },
   {

--- a/examples/notebook/test_raddriver.ipynb
+++ b/examples/notebook/test_raddriver.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "b2625312-8234-4ed3-be7d-bd4118b75489",
    "metadata": {},
    "outputs": [],
@@ -88,9 +88,7 @@
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
     ")\n",
-    "quantity_factory = QuantityFactory.from_backend(\n",
-    "    sizer, backend=\"numpy\"\n",
-    ")"
+    "quantity_factory = QuantityFactory(sizer, backend=\"numpy\")"
    ]
   },
   {

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -128,7 +128,7 @@ def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
         tile_partitioner=communicator.partitioner.tile,
         tile_rank=communicator.tile.rank,
     )
-    quantity_factory = QuantityFactory.from_backend(sizer, backend="numpy")
+    quantity_factory = QuantityFactory(sizer, backend="numpy")
 
     soil_sizer = SubtileGridSizer.from_tile_params(
         nx_tile=nx,
@@ -140,7 +140,7 @@ def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
         tile_partitioner=communicator.partitioner.tile,
         tile_rank=communicator.tile.rank,
     )
-    qf_soil = QuantityFactory.from_backend(soil_sizer, backend="numpy")
+    qf_soil = QuantityFactory(soil_sizer, backend="numpy")
 
     comconf = CompilationConfig()
     comconf.validate_args = False

--- a/tests/savepoint/translate/translate_atmos_phy_statein.py
+++ b/tests/savepoint/translate/translate_atmos_phy_statein.py
@@ -60,8 +60,8 @@ class TranslateAtmosPhysDriverStatein(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
         self.compute_func = self.stencil_factory.from_origin_domain(
             atmos_phys_driver_statein,

--- a/tests/savepoint/translate/translate_cloud_frac.py
+++ b/tests/savepoint/translate/translate_cloud_frac.py
@@ -346,8 +346,8 @@ class TranslateCloudFrac(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_cumulative_shalconv.py
+++ b/tests/savepoint/translate/translate_cumulative_shalconv.py
@@ -3405,8 +3405,8 @@ class TranslateInitCol(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -3518,8 +3518,8 @@ class TranslateStatic1(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -3623,8 +3623,8 @@ class TranslateStatic2(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -3740,8 +3740,8 @@ class TranslateUpdateKb9(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -3853,8 +3853,8 @@ class TranslateStatic10(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -4020,8 +4020,8 @@ class TranslateStatic11(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -4185,8 +4185,8 @@ class TranslateStatic12(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -4320,8 +4320,8 @@ class TranslateFeedbackCtrl(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -4381,8 +4381,8 @@ class TranslateSC13(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -4535,8 +4535,8 @@ class TranslateCompTendencies(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing

--- a/tests/savepoint/translate/translate_final_mp.py
+++ b/tests/savepoint/translate/translate_final_mp.py
@@ -1036,8 +1036,8 @@ class TranslateFinalCalculations(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            self.sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            self.sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):
@@ -1493,8 +1493,8 @@ class TranslatePostMP(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            self.sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            self.sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_gfdl_cld_microphysics.py
+++ b/tests/savepoint/translate/translate_gfdl_cld_microphysics.py
@@ -330,8 +330,8 @@ class TranslateMicrophysics3(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            self.sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            self.sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -129,9 +129,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         schemes = [PHYSICS_PACKAGES["GFS_microphysics"]]
         physics_state = PhysicsState(
             **inputs,

--- a/tests/savepoint/translate/translate_mfpblt.py
+++ b/tests/savepoint/translate/translate_mfpblt.py
@@ -64,9 +64,7 @@ class TranslateMFPBLT(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         k_mask = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],

--- a/tests/savepoint/translate/translate_mfscu.py
+++ b/tests/savepoint/translate/translate_mfscu.py
@@ -67,9 +67,7 @@ class TranslateMFSCU(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         k_mask = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],

--- a/tests/savepoint/translate/translate_microphysics.py
+++ b/tests/savepoint/translate/translate_microphysics.py
@@ -81,9 +81,7 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         physics_state = PhysicsState.init_from_storages(
             inputs,
             sizer=sizer,

--- a/tests/savepoint/translate/translate_mp_full.py
+++ b/tests/savepoint/translate/translate_mp_full.py
@@ -468,8 +468,8 @@ class TranslateMPFull(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):
@@ -697,8 +697,8 @@ class TranslateMPSub(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_particle_properties.py
+++ b/tests/savepoint/translate/translate_particle_properties.py
@@ -502,8 +502,8 @@ class TranslateParticleProperties(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            self.sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            self.sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_pbl.py
+++ b/tests/savepoint/translate/translate_pbl.py
@@ -99,9 +99,7 @@ class TranslatePBL(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 

--- a/tests/savepoint/translate/translate_pbl_subtests.py
+++ b/tests/savepoint/translate/translate_pbl_subtests.py
@@ -3331,9 +3331,7 @@ class TranslatePBLInit(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3441,9 +3439,7 @@ class TranslateMRF(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3510,9 +3506,7 @@ class TranslateThermalPBL(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3568,9 +3562,7 @@ class TranslateStratocumulus(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3640,9 +3632,7 @@ class TranslatePBLAML(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3715,9 +3705,7 @@ class TranslateTKETridiagEle(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3775,9 +3763,7 @@ class TranslatePrandtl(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3925,9 +3911,7 @@ class TranslateEdDiffShear(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -3988,9 +3972,7 @@ class TranslateUpDownTKE(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         config = self.config.pbl
 
         self.make_storage_data_input_vars(inputs)
@@ -4084,9 +4066,7 @@ class TranslateMomentTridiagComp(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         config = self.config.pbl
 
         self.make_storage_data_input_vars(inputs)
@@ -4168,9 +4148,7 @@ class TranslateHeatTracerTridiagEle(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         config = self.config.pbl
 
         self.make_storage_data_input_vars(inputs)
@@ -4236,9 +4214,7 @@ class TranslateTKETendencyCalc(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -4321,9 +4297,7 @@ class TranslateHeatTracerTendencyCalc(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         config = self.config.pbl
         config.ntke = config.ntracers - 1
@@ -4411,9 +4385,7 @@ class TranslateMomentTendencyCalc(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -4634,9 +4606,7 @@ class TranslateHalf2(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 
@@ -4877,9 +4847,7 @@ class TranslateSCUEnd(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
 

--- a/tests/savepoint/translate/translate_preliminary_mp.py
+++ b/tests/savepoint/translate/translate_preliminary_mp.py
@@ -574,8 +574,8 @@ class TranslatePreliminaryCalculations(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            self.sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            self.sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_samfshalconv.py
+++ b/tests/savepoint/translate/translate_samfshalconv.py
@@ -81,8 +81,8 @@ class TranslateShalConv(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
         self.grid_indexing = stencil_factory.grid_indexing
@@ -97,9 +97,7 @@ class TranslateShalConv(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         quantity_factory.add_data_dimensions(
             {
                 SC_TRACER_DIM: inputs["sc_nsamftrac"] + 2,

--- a/tests/savepoint/translate/translate_sedimentation.py
+++ b/tests/savepoint/translate/translate_sedimentation.py
@@ -697,8 +697,8 @@ class TranslateSedimentation(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):
@@ -875,8 +875,8 @@ class TranslateSediMelt(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_terminal_fall.py
+++ b/tests/savepoint/translate/translate_terminal_fall.py
@@ -137,8 +137,8 @@ class TranslateTerminalFall(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_tracer_sedi.py
+++ b/tests/savepoint/translate/translate_tracer_sedi.py
@@ -720,8 +720,8 @@ class TranslateTracerSed(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        self.quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
+        self.quantity_factory = QuantityFactory(
+            sizer, backend=self.stencil_factory.backend
         )
 
     def compute(self, inputs):

--- a/tests/savepoint/translate/translate_tridiag.py
+++ b/tests/savepoint/translate/translate_tridiag.py
@@ -229,9 +229,7 @@ class TranslateTridit(TranslatePhysicsFortranData2Py):
             layout=self.config.layout,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         self.make_storage_data_input_vars(inputs)
         compute_func = TridiT(self.stencil_factory, quantity_factory)
@@ -271,9 +269,7 @@ class TranslateTridi2(TranslatePhysicsFortranData2Py):
             data_dimensions={},
             layout=self.config.layout,
         )
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         compute_func = Tridi2(self.stencil_factory, quantity_factory)
 
         compute_func(**inputs)
@@ -312,9 +308,7 @@ class TranslateTridin(TranslatePhysicsFortranData2Py):
             data_dimensions={},
             layout=self.config.layout,
         )
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         config = self.config.pbl
         compute_func = TridiN(self.stencil_factory, quantity_factory, 8)
 


### PR DESCRIPTION
**Description**

Prefer the new constructor of `QuantityFactory` over the deprecated call to `QuantityFactory.from_backend(...)`. This removes a bunch of deprecation warnings in tests.

See https://github.com/NOAA-GFDL/NDSL/pull/228 for context.

/cc @FlorianDeconinck 

**How Has This Been Tested?**

Search and manual replace of `from_backend` within pySHiELD. CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
