### PR TITLE
ci: re-enable `mypy` for pySHiELD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
       - id: mypy
         name: mypy-physics
         args: ["--config-file", "pyproject.toml"]
-        files: pySHiELD
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/examples/notebook/utilities.py
+++ b/examples/notebook/utilities.py
@@ -24,7 +24,7 @@ def states_from_fortran_restarts(
     tracer_datafile: Path,
     ak: Quantity,
     quantity_factory: QuantityFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     dycore_data = xr.open_dataset(dycore_datafile)
     phys_data = xr.open_dataset(phys_datafile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,13 +88,19 @@ sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 use_parentheses = true
 
 [tool.mypy]
-exclude = ["tests/conftest.py"]
 explicit_package_bases = true
 follow_imports = "normal"
 ignore_missing_imports = true
 namespace_packages = true
 strict_optional = false
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = [
+  # We currently can't type tracers correctly
+  "pyshield.stencils.*"
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyshield/stencils/pbl/_config.py
+++ b/pyshield/stencils/pbl/_config.py
@@ -10,7 +10,7 @@ DEFAULT_BOOL = False
 
 @dataclasses.dataclass
 class PBLConfig:
-    dt_atmos: int = DEFAULT_INT
+    dt_atmos: float = DEFAULT_FLOAT
     hydrostatic: bool = DEFAULT_BOOL
     isatmedmf: int = 0
     """flag for specific scale-aware turbulent moist edmf scheme"""
@@ -44,9 +44,9 @@ class PBLConfig:
     do_dk_hb19: bool = DEFAULT_BOOL
     """Flag to use HB19 background diffusion formula in satmedmf"""
     rlmn: float = 30.0
-    """Lower limit on aymptotic mixing length in satmedmf"""
+    """Lower limit on asymptotic mixing length in satmedmf"""
     rlmx: float = 300.0
-    """Upper limit on aymptotic mixing length in satmedmf"""
+    """Upper limit on asymptotic mixing length in satmedmf"""
     ntracers: int = int(len(tracer_variables))
     """Number of tracers"""
     ntiw: int = DEFAULT_INT

--- a/pyshield/stencils/pbl/mfpblt.py
+++ b/pyshield/stencils/pbl/mfpblt.py
@@ -1,5 +1,5 @@
 import ndsl.constants as constants
-import pyshield.stencils.pbl.constants as pblcons
+import pyshield.stencils.pbl.constants as pbl_constants
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval, sqrt
 
@@ -85,7 +85,7 @@ def mfpblt_s1(
     with computation(FORWARD), interval(0, 1):
         # Compute thermal excess
         if cnvflg[0, 0]:
-            ptem = pblcons.ALP * vpert[0, 0]
+            ptem = pbl_constants.ALP * vpert[0, 0]
             ptem = min(ptem, 3.0)
             thlu = thlx[0, 0, 0] + ptem
             qtu = qtx[0, 0, 0]
@@ -99,10 +99,10 @@ def mfpblt_s1(
                 ptem = 1.0 / (zm[0, 0, 0] + dz)
                 tem = max((hpbl[0, 0] - zm[0, 0, 0] + dz), dz)
                 ptem1 = 1.0 / tem
-                xlamue = pblcons.CE0 * (ptem + ptem1)
+                xlamue = pbl_constants.CE0 * (ptem + ptem1)
             else:
-                xlamue = pblcons.CE0 / dz
-            xlamuem = pblcons.CM * xlamue[0, 0, 0]
+                xlamue = pbl_constants.CE0 / dz
+            xlamuem = pbl_constants.CM * xlamue[0, 0, 0]
 
     with computation(FORWARD):
         with interval(1, None):
@@ -122,18 +122,18 @@ def mfpblt_s1(
                 tlu = thlu[0, 0, 0] / pix[0, 0, 0]
                 es = 0.01 * fpvs(tlu)
                 qs = max(
-                    pblcons.PBL_QMIN,
+                    pbl_constants.PBL_QMIN,
                     constants.EPS * es / (plyr[0, 0, 0] + constants.EPSM1 * es),
                 )
                 dq = qtu[0, 0, 0] - qs
 
                 if dq > 0.0:
-                    gamma = pblcons.EL2ORC * qs / (tlu**2)
+                    gamma = pbl_constants.EL2ORC * qs / (tlu**2)
                     qlu = dq / (1.0 + gamma)
                     qtu = qs + qlu
-                    thvu = (thlu[0, 0, 0] + pix[0, 0, 0] * pblcons.ELOCP * qlu) * (
-                        1.0 + constants.ZVIR * qs - qlu
-                    )
+                    thvu = (
+                        thlu[0, 0, 0] + pix[0, 0, 0] * pbl_constants.ELOCP * qlu
+                    ) * (1.0 + constants.ZVIR * qs - qlu)
                 else:
                     thvu = thlu[0, 0, 0] * (1.0 + constants.ZVIR * qtu[0, 0, 0])
                 buo = constants.GRAV * (thvu / thvx[0, 0, 0] - 1.0)
@@ -241,10 +241,10 @@ def mfpblt_s2(
             if k_mask[0, 0, 0] < kpbl[0, 0]:
                 ptem = 1 / (zm[0, 0, 0] + dz)
                 ptem1 = 1 / max(hpbl[0, 0] - zm[0, 0, 0] + dz, dz)
-                xlamue = pblcons.CE0 * (ptem + ptem1)
+                xlamue = pbl_constants.CE0 * (ptem + ptem1)
             else:
-                xlamue = pblcons.CE0 / dz
-            xlamuem = pblcons.CM * xlamue[0, 0, 0]
+                xlamue = pbl_constants.CE0 / dz
+            xlamuem = pbl_constants.CM * xlamue[0, 0, 0]
 
     # Compute entrainment rate averaged over the whole pbl
     with computation(FORWARD), interval(...):
@@ -310,16 +310,16 @@ def mfpblt_s2(
                 tlu = thlu[0, 0, 0] / pix[0, 0, 0]
                 es = 0.01 * fpvs(tlu)  # fpvs in pa
                 qs = max(
-                    pblcons.PBL_QMIN,
+                    pbl_constants.PBL_QMIN,
                     constants.EPS * es / (plyr[0, 0, 0] + constants.EPSM1 * es),
                 )
                 dq = qtu[0, 0, 0] - qs
                 if dq > 0.0:
-                    qlu = dq / (1.0 + (pblcons.EL2ORC * qs / (tlu**2)))
+                    qlu = dq / (1.0 + (pbl_constants.EL2ORC * qs / (tlu**2)))
                     qtu = qs + qlu
                     qcko[0, 0, 0][0] = qs
                     qcko[0, 0, 0][ntcw] = qlu
-                    tcko = tlu + pblcons.ELOCP * qlu
+                    tcko = tlu + pbl_constants.ELOCP * qlu
                 else:
                     qcko[0, 0, 0][0] = qtu[0, 0, 0]
                     qcko[0, 0, 0][ntcw] = 0.0
@@ -331,13 +331,13 @@ def mfpblt_s2(
                 factor = 1.0 + tem
                 ucko = (
                     (1.0 - tem) * ucko[0, 0, -1]
-                    + (tem + pblcons.PGCON) * u1[0, 0, 0]
-                    + (tem - pblcons.PGCON) * u1[0, 0, -1]
+                    + (tem + pbl_constants.PGCON) * u1[0, 0, 0]
+                    + (tem - pbl_constants.PGCON) * u1[0, 0, -1]
                 ) / factor
                 vcko = (
                     (1.0 - tem) * vcko[0, 0, -1]
-                    + (tem + pblcons.PGCON) * v1[0, 0, 0]
-                    + (tem - pblcons.PGCON) * v1[0, 0, -1]
+                    + (tem + pbl_constants.PGCON) * v1[0, 0, 0]
+                    + (tem - pbl_constants.PGCON) * v1[0, 0, -1]
                 ) / factor
 
 

--- a/pyshield/stencils/pbl/mfscu.py
+++ b/pyshield/stencils/pbl/mfscu.py
@@ -1,5 +1,5 @@
 import ndsl.constants as constants
-import pyshield.stencils.pbl.constants as pblcons
+import pyshield.stencils.pbl.constants as pbl_constants
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 
@@ -59,23 +59,23 @@ def mfscu_s0(
                 hrad = zm[0, 0, 0]
                 krad1 = krad[0, 0] - 1
                 tem = zm[0, 0, 1] - zm[0, 0, 0]
-                tem1 = pblcons.CLDTIME * radmin[0, 0] / tem
+                tem1 = pbl_constants.CLDTIME * radmin[0, 0] / tem
                 tem1 = max(tem1, -3.0)
                 thld = thlx[0, 0, 0] + tem1
                 qtd = qtx[0, 0, 0]
                 thlvd = thlvx[0, 0, 0] + tem1
                 buo = -constants.GRAV * tem1 / thvx[0, 0, 0]
 
-                ra1 = pblcons.A1
-                ra2 = pblcons.A11
+                ra1 = pbl_constants.A1
+                ra2 = pbl_constants.A11
 
                 tem2 = thetae[0, 0, 0] - thetae[0, 0, 1]
                 tem3 = qtx[0, 0, 0] - qtx[0, 0, 1]
                 if (tem2 > 0.0) and (tem3 > 0.0):
                     cteit = constants.CP_AIR * tem2 / (constants.HLV * tem3)
-                    if cteit > pblcons.ACTEI:
-                        ra1 = pblcons.A2
-                        ra2 = pblcons.A22
+                    if cteit > pbl_constants.ACTEI:
+                        ra1 = pbl_constants.A2
+                        ra2 = pbl_constants.A22
 
                 radj = -ra2[0, 0] * radmin[0, 0]
 
@@ -125,18 +125,18 @@ def mfscu_s2(
             dz = zl[0, 0, 1] - zl[0, 0, 0]
             if k_mask[0, 0, 0] >= mrad[0, 0] and k_mask[0, 0, 0] < krad[0, 0]:
                 if mrad[0, 0] == 0:
-                    xlamde = pblcons.CE0 * (
+                    xlamde = pbl_constants.CE0 * (
                         (1.0 / (zm[0, 0, 0] + dz))
                         + 1.0 / max(hrad[0, 0] - zm[0, 0, 0] + dz, dz)
                     )
                 else:
-                    xlamde = pblcons.CE0 * (
+                    xlamde = pbl_constants.CE0 * (
                         (1.0 / (zm[0, 0, 0] - zm_mrad[0, 0] + dz))
                         + 1.0 / max(hrad[0, 0] - zm[0, 0, 0] + dz, dz)
                     )
             else:
-                xlamde = pblcons.CE0 / dz
-            xlamdem = pblcons.CM * xlamde[0, 0, 0]
+                xlamde = pbl_constants.CE0 / dz
+            xlamdem = pbl_constants.CM * xlamde[0, 0, 0]
 
 
 def mfscu_s3(
@@ -170,17 +170,17 @@ def mfscu_s3(
         tld = thld[0, 0, 0] / pix[0, 0, 0]
         es = 0.01 * fpvs(tld)
         qs = max(
-            pblcons.PBL_QMIN,
+            pbl_constants.PBL_QMIN,
             constants.EPS * es / (plyr[0, 0, 0] + constants.EPSM1 * es),
         )
         dq = qtd[0, 0, 0] - qs
-        gamma = pblcons.EL2ORC * qs / (tld**2)
+        gamma = pbl_constants.EL2ORC * qs / (tld**2)
         qld = dq / (1.0 + gamma)
         if cnvflg[0, 0] and k_mask[0, 0, 0] < krad[0, 0]:
             if dq > 0.0:
                 qtd = qs + qld
                 tem1 = 1.0 + constants.ZVIR * qs - qld
-                thdn = thld[0, 0, 0] + pix[0, 0, 0] * pblcons.ELOCP * qld
+                thdn = thld[0, 0, 0] + pix[0, 0, 0] * pbl_constants.ELOCP * qld
                 thvd = thdn * tem1
             else:
                 tem1 = 1.0 + constants.ZVIR * qtd[0, 0, 0]
@@ -272,18 +272,18 @@ def mfscu_s6(
             dz = zl[0, 0, 1] - zl[0, 0, 0]
             if k_mask[0, 0, 0] >= mrad[0, 0] and k_mask[0, 0, 0] < krad[0, 0]:
                 if mrad[0, 0] == 0:
-                    xlamde = pblcons.CE0 * (
+                    xlamde = pbl_constants.CE0 * (
                         (1.0 / (zm[0, 0, 0] + dz))
                         + 1.0 / max(hrad[0, 0] - zm[0, 0, 0] + dz, dz)
                     )
                 else:
-                    xlamde = pblcons.CE0 * (
+                    xlamde = pbl_constants.CE0 * (
                         (1.0 / (zm[0, 0, 0] - zm_mrad[0, 0] + dz))
                         + 1.0 / max(hrad[0, 0] - zm[0, 0, 0] + dz, dz)
                     )
             else:
-                xlamde = pblcons.CE0 / dz
-            xlamdem = pblcons.CM * xlamde[0, 0, 0]
+                xlamde = pbl_constants.CE0 / dz
+            xlamdem = pbl_constants.CM * xlamde[0, 0, 0]
 
 
 def mfscu_s7(
@@ -421,18 +421,18 @@ def mfscu_s9(
             tld = thld[0, 0, 0] / pix[0, 0, 0]
             es = 0.01 * fpvs(tld)
             qs = max(
-                pblcons.PBL_QMIN,
+                pbl_constants.PBL_QMIN,
                 constants.EPS * es / (plyr[0, 0, 0] + constants.EPSM1 * es),
             )
             dq = qtd[0, 0, 0] - qs
-            gamma = pblcons.EL2ORC * qs / (tld**2)
+            gamma = pbl_constants.EL2ORC * qs / (tld**2)
             qld = dq / (1.0 + gamma)
 
             if dq > 0.0:
                 qtd = qs + qld
                 qcdo[0, 0, 0][0] = qs
                 qcdo[0, 0, 0][ntcw] = qld
-                tcdo = tld + pblcons.ELOCP * qld
+                tcdo = tld + pbl_constants.ELOCP * qld
             else:
                 qcdo[0, 0, 0][0] = qtd[0, 0, 0]
                 qcdo[0, 0, 0][ntcw] = 0.0
@@ -445,8 +445,8 @@ def mfscu_s9(
         ):
             tem = 0.5 * xlamdem[0, 0, 0] * dz
             factor = 1.0 + tem
-            ptem = tem - pblcons.PGCON
-            ptem1 = tem + pblcons.PGCON
+            ptem = tem - pbl_constants.PGCON
+            ptem1 = tem + pbl_constants.PGCON
             ucdo = (
                 (1.0 - tem) * ucdo[0, 0, 1] + ptem * u1[0, 0, 1] + ptem1 * u1[0, 0, 0]
             ) / factor

--- a/pyshield/stencils/pbl/satmedmfvdiff.py
+++ b/pyshield/stencils/pbl/satmedmfvdiff.py
@@ -1,5 +1,5 @@
 import ndsl.constants as constants
-import pyshield.stencils.pbl.constants as pblcons
+import pyshield.stencils.pbl.constants as pbl_constants
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, sqrt
 
@@ -159,9 +159,9 @@ def init_turbulence(
         with interval(0, -1):
             zi = phii[0, 0, 0] * constants.RGRAV
             zl = phil[0, 0, 0] * constants.RGRAV
-            tke = max(q1[0, 0, 0][ntke], pblcons.TKMIN)
-            ckz = pblcons.CK1
-            chz = pblcons.CH1
+            tke = max(q1[0, 0, 0][ntke], pbl_constants.TKMIN)
+            ckz = pbl_constants.CK1
+            chz = pbl_constants.CH1
         with interval(-1, None):
             zi = phii[0, 0, 0] * constants.RGRAV
     with computation(FORWARD):
@@ -179,7 +179,7 @@ def init_turbulence(
         tx1 = 1.0 / prsi[0, 0, 0]
         tx2 = 1.0 / prsi[0, 0, 0]
         if do_dk_hb19:
-            if gdx[0, 0] >= pblcons.XKGDX:
+            if gdx[0, 0] >= pbl_constants.XKGDX:
                 if islimsk == 1:  # Land points
                     xkzm_hx = xkzm_hl
                     xkzm_mx = xkzm_ml
@@ -190,7 +190,7 @@ def init_turbulence(
                     xkzm_hx = xkzm_ho
                     xkzm_mx = xkzm_mo
             else:
-                tem = 1.0 / (pblcons.XKGDX - 5.0)
+                tem = 1.0 / (pbl_constants.XKGDX - 5.0)
                 if islimsk == 1:  # Land points
                     tem1 = (xkzm_hl - xkzm_lim) * tem
                     tem2 = (xkzm_ml - xkzm_lim) * tem
@@ -236,13 +236,13 @@ def init_turbulence(
         pix = psk[0, 0] / prslk[0, 0, 0]
         theta = t1[0, 0, 0] * pix[0, 0, 0]
         if (ntiw + 1) > 0:
-            tem = max(q1[0, 0, 0][ntcw], pblcons.QLMIN)
-            tem1 = max(q1[0, 0, 0][ntiw], pblcons.QLMIN)
+            tem = max(q1[0, 0, 0][ntcw], pbl_constants.QLMIN)
+            tem1 = max(q1[0, 0, 0][ntiw], pbl_constants.QLMIN)
             ptem = constants.HLV * tem + (constants.HLV + constants.HLF) * tem1
             qlx = tem + tem1
             slx = constants.CP_AIR * t1[0, 0, 0] + phil[0, 0, 0] - ptem
         else:
-            qlx = max(q1[0, 0, 0][ntcw], pblcons.QLMIN)
+            qlx = max(q1[0, 0, 0][ntcw], pbl_constants.QLMIN)
             slx = (
                 constants.CP_AIR * t1[0, 0, 0]
                 + phil[0, 0, 0]
@@ -250,16 +250,18 @@ def init_turbulence(
             )
 
         tem2 = (
-            1.0 + constants.ZVIR * max(q1[0, 0, 0][0], pblcons.PBL_QMIN) - qlx[0, 0, 0]
+            1.0
+            + constants.ZVIR * max(q1[0, 0, 0][0], pbl_constants.PBL_QMIN)
+            - qlx[0, 0, 0]
         )
         thvx = theta[0, 0, 0] * tem2
         tvx = t1 * tem2
-        qtx = max(q1[0, 0, 0][0], pblcons.PBL_QMIN) + qlx[0, 0, 0]
-        thlx = theta[0, 0, 0] - pix[0, 0, 0] * pblcons.ELOCP * qlx[0, 0, 0]
+        qtx = max(q1[0, 0, 0][0], pbl_constants.PBL_QMIN) + qlx[0, 0, 0]
+        thlx = theta[0, 0, 0] - pix[0, 0, 0] * pbl_constants.ELOCP * qlx[0, 0, 0]
         thlvx = thlx[0, 0, 0] * (1.0 + constants.ZVIR * qtx[0, 0, 0])
         svx = constants.CP_AIR * tvx
-        thetae = theta[0, 0, 0] + pblcons.ELOCP * pix[0, 0, 0] * max(
-            q1[0, 0, 0][0], pblcons.PBL_QMIN
+        thetae = theta[0, 0, 0] + pbl_constants.ELOCP * pix[0, 0, 0] * max(
+            q1[0, 0, 0][0], pbl_constants.PBL_QMIN
         )
         gotvx = constants.GRAV / (tvx)
 
@@ -283,10 +285,10 @@ def init_turbulence(
         plyr = 0.01 * prsl[0, 0, 0]
         es = 0.01 * fpvs(t1)
         qs = max(
-            pblcons.PBL_QMIN,
+            pbl_constants.PBL_QMIN,
             constants.EPS * es / (plyr[0, 0, 0] + (constants.EPS - 1) * es),
         )
-        rhly = max(0.0, min(1.0, max(pblcons.PBL_QMIN, q1[0, 0, 0][0]) / qs))
+        rhly = max(0.0, min(1.0, max(pbl_constants.PBL_QMIN, q1[0, 0, 0][0]) / qs))
         qstl = qs
 
     with computation(FORWARD), interval(0, -1):
@@ -294,7 +296,9 @@ def init_turbulence(
         clwt = 1.0e-6 * (plyr[0, 0, 0] * 0.001)
         if qlx[0, 0, 0] > clwt:
             onemrh = max(1.0e-10, 1.0 - rhly[0, 0, 0])
-            tem1 = pblcons.CQL / min(max((onemrh * qstl[0, 0, 0]) ** 0.49, 0.0001), 1.0)
+            tem1 = pbl_constants.CQL / min(
+                max((onemrh * qstl[0, 0, 0]) ** 0.49, 0.0001), 1.0
+            )
             val = max(min(tem1 * qlx[0, 0, 0], 50.0), 0.0)
             cfly = min(max(sqrt(sqrt(rhly[0, 0, 0])) * (1.0 - exp(-val)), 0.0), 1.0)
 
@@ -303,8 +307,10 @@ def init_turbulence(
         tem1 = 0.5 * (t1[0, 0, 0] + t1[0, 0, 1])
         cfh = min(cfly[0, 0, 1], 0.5 * (cfly[0, 0, 0] + cfly[0, 0, 1]))
         alp = constants.GRAV / (0.5 * (svx[0, 0, 0] + svx[0, 0, 1]))
-        gamma = pblcons.EL2ORC * (0.5 * (qstl[0, 0, 0] + qstl[0, 0, 1])) / (tem1**2)
-        epsi = tem1 / pblcons.ELOCP
+        gamma = (
+            pbl_constants.EL2ORC * (0.5 * (qstl[0, 0, 0] + qstl[0, 0, 1])) / (tem1**2)
+        )
+        epsi = tem1 / pbl_constants.ELOCP
         beta = (1.0 + gamma * epsi * (1.0 + constants.ZVIR)) / (1.0 + gamma)
         chx = cfh * alp * beta + (1.0 - cfh) * alp
         cqx = cfh * alp * constants.HLV * (beta - epsi)
@@ -324,16 +330,19 @@ def init_turbulence(
 
             if pblflg[0, 0]:
                 thermal = thlvx[0, 0, 0]
-                crb = pblcons.RBCR
+                crb = pbl_constants.RBCR
             else:
                 tem1 = 1e-7 * (
                     max(sqrt(u10m[0, 0] ** 2 + v10m[0, 0] ** 2), 1.0)
-                    / (pblcons.F0 * 0.01 * zorl[0, 0])
+                    / (pbl_constants.F0 * 0.01 * zorl[0, 0])
                 )
                 thermal = tsea[0, 0] * (
-                    1.0 + constants.ZVIR * max(q1[0, 0, 0][0], pblcons.PBL_QMIN)
+                    1.0 + constants.ZVIR * max(q1[0, 0, 0][0], pbl_constants.PBL_QMIN)
                 )
-                crb = max(min(0.16 * (tem1 ** (-0.18)), pblcons.CRBMAX), pblcons.CRBMIN)
+                crb = max(
+                    min(0.16 * (tem1 ** (-0.18)), pbl_constants.CRBMAX),
+                    pbl_constants.CRBMIN,
+                )
 
             dtdz1 = dt2 / (zi[0, 0, 1] - zi[0, 0, 0])
             ustar = sqrt(stress[0, 0])
@@ -341,7 +350,7 @@ def init_turbulence(
     with computation(FORWARD):
         with interval(0, -2):
             dw2 = (u1[0, 0, 0] - u1[0, 0, 1]) ** 2 + (v1[0, 0, 0] - v1[0, 0, 1]) ** 2
-            shr2 = max(dw2, pblcons.DW2MIN) * rdzt[0, 0, 0] * rdzt[0, 0, 0]
+            shr2 = max(dw2, pbl_constants.DW2MIN) * rdzt[0, 0, 0] * rdzt[0, 0, 0]
         with interval(-2, -1):
             ptop = phii
 
@@ -437,31 +446,37 @@ def mrf_pbl_2_thermal_excess(
             pblflg = False
 
         # Compute similarity parameters
-        zol = max(rbsoil[0, 0] * fm[0, 0] * fm[0, 0] / fh[0, 0], pblcons.RIMIN)
+        zol = max(rbsoil[0, 0] * fm[0, 0] * fm[0, 0] / fh[0, 0], pbl_constants.RIMIN)
         if sfcflg[0, 0]:
-            zol = min(zol[0, 0], -pblcons.ZFMIN)
+            zol = min(zol[0, 0], -pbl_constants.ZFMIN)
         else:
-            zol = max(zol[0, 0], pblcons.ZFMIN)
+            zol = max(zol[0, 0], pbl_constants.ZFMIN)
 
-        zol1 = zol[0, 0] * pblcons.SFCFRAC * hpbl[0, 0] / zl[0, 0, 0]
+        zol1 = zol[0, 0] * pbl_constants.SFCFRAC * hpbl[0, 0] / zl[0, 0, 0]
 
         if sfcflg[0, 0]:
-            phih = sqrt(1.0 / (1.0 - pblcons.APHI16 * zol1))
+            phih = sqrt(1.0 / (1.0 - pbl_constants.APHI16 * zol1))
             phim = sqrt(phih[0, 0])
         else:
-            phim = 1.0 + pblcons.APHI5 * zol1
+            phim = 1.0 + pbl_constants.APHI5 * zol1
             phih = phim[0, 0]
 
-        pcnvflg = pblflg[0, 0] and (zol[0, 0] < pblcons.ZOLCRU)
+        pcnvflg = pblflg[0, 0] and (zol[0, 0] < pbl_constants.ZOLCRU)
 
         wst3 = gotvx[0, 0, 0] * sflux[0, 0] * hpbl[0, 0]
         ust3 = ustar[0, 0] ** 3.0
 
         if pblflg[0, 0]:
             wscale = max(
-                (ust3 + pblcons.WFAC * pblcons.VK * wst3 * pblcons.SFCFRAC)
-                ** pblcons.H1,
-                ustar[0, 0] / pblcons.APHI5,
+                (
+                    ust3
+                    + pbl_constants.WFAC
+                    * pbl_constants.VK
+                    * wst3
+                    * pbl_constants.SFCFRAC
+                )
+                ** pbl_constants.H1,
+                ustar[0, 0] / pbl_constants.APHI5,
             )
 
         flg = 1
@@ -471,7 +486,9 @@ def mrf_pbl_2_thermal_excess(
             hgamt = heat[0, 0] / wscale
             hgamq = evap[0, 0] / wscale
             vpert = max(hgamt + hgamq * constants.ZVIR * theta[0, 0, 0], 0.0)
-            thermal = thermal[0, 0] + min(pblcons.CFAC * vpert[0, 0], pblcons.GAMCRT)
+            thermal = thermal[0, 0] + min(
+                pbl_constants.CFAC * vpert[0, 0], pbl_constants.GAMCRT
+            )
             flg = 0
             rbup = rbsoil[0, 0]
 
@@ -555,11 +572,11 @@ def stratocumulus(
     with computation(FORWARD):
         with interval(0, 1):
             flg = scuflg[0, 0]
-            if flg[0, 0] and (zl[0, 0, 0] >= pblcons.ZSTBLMAX):
+            if flg[0, 0] and (zl[0, 0, 0] >= pbl_constants.ZSTBLMAX):
                 lcld = k_mask[0, 0, 0]
                 flg = 0
         with interval(1, -1):
-            if flg[0, 0] and (zl[0, 0, 0] >= pblcons.ZSTBLMAX):
+            if flg[0, 0] and (zl[0, 0, 0] >= pbl_constants.ZSTBLMAX):
                 lcld = k_mask[0, 0, 0]
                 flg = 0
 
@@ -572,7 +589,7 @@ def stratocumulus(
             if (
                 flg[0, 0]
                 and (k_mask[0, 0, 0] <= lcld[0, 0])
-                and (qlx[0, 0, 0] >= pblcons.QLCR)
+                and (qlx[0, 0, 0] >= pbl_constants.QLCR)
             ):
                 kcld = k_mask[0, 0, 0]
                 flg = 0
@@ -581,7 +598,7 @@ def stratocumulus(
             if (
                 flg[0, 0]
                 and (k_mask[0, 0, 0] <= lcld[0, 0])
-                and (qlx[0, 0, 0] >= pblcons.QLCR)
+                and (qlx[0, 0, 0] >= pbl_constants.QLCR)
             ):
                 kcld = k_mask[0, 0, 0]
                 flg = 0
@@ -595,7 +612,7 @@ def stratocumulus(
     with computation(BACKWARD):
         with interval(-1, None):
             if flg[0, 0] and (k_mask[0, 0, 0] <= kcld[0, 0]):
-                if qlx[0, 0, 0] >= pblcons.QLCR:
+                if qlx[0, 0, 0] >= pbl_constants.QLCR:
                     if radx[0, 0, 0] < radmin[0, 0]:
                         radmin = radx[0, 0, 0]
                         krad = k_mask[0, 0, 0]
@@ -604,7 +621,7 @@ def stratocumulus(
 
         with interval(0, -1):
             if flg[0, 0] and (k_mask[0, 0, 0] <= kcld[0, 0]):
-                if qlx[0, 0, 0] >= pblcons.QLCR:
+                if qlx[0, 0, 0] >= pbl_constants.QLCR:
                     if radx[0, 0, 0] < radmin[0, 0]:
                         radmin = radx[0, 0, 0]
                         krad = k_mask[0, 0, 0]
@@ -676,7 +693,7 @@ def compute_prandtl_num_exchange_coeff(
             tem = phih[0, 0] / phim[0, 0]
             ptem = (
                 -3.0
-                * (max(zi[0, 0, 1] - pblcons.SFCFRAC * hpbl[0, 0], 0.0) ** 2.0)
+                * (max(zi[0, 0, 1] - pbl_constants.SFCFRAC * hpbl[0, 0], 0.0) ** 2.0)
                 / hpbl[0, 0] ** 2.0
             )
             if pcnvflg[0, 0]:
@@ -684,18 +701,20 @@ def compute_prandtl_num_exchange_coeff(
             else:
                 prn = tem
 
-            prn = min(prn, pblcons.PRMAX)
-            prn = max(prn, pblcons.PRMIN)
+            prn = min(prn, pbl_constants.PRMAX)
+            prn = max(prn, pbl_constants.PRMIN)
             ckz = min(
-                pblcons.CK1 + (pblcons.CK0 - pblcons.CK1) * exp(ptem), pblcons.CK0
+                pbl_constants.CK1 + (pbl_constants.CK0 - pbl_constants.CK1) * exp(ptem),
+                pbl_constants.CK0,
             )
-            ckz = max(ckz, pblcons.CK1)
+            ckz = max(ckz, pbl_constants.CK1)
             chz = min(
-                pblcons.CH1 + (pblcons.CH0 - pblcons.CH1) * exp(ptem), pblcons.CH0
+                pbl_constants.CH1 + (pbl_constants.CH0 - pbl_constants.CH1) * exp(ptem),
+                pbl_constants.CH0,
             )
             chz = max(
                 chz,
-                pblcons.CH1,
+                pbl_constants.CH1,
             )
 
 
@@ -736,9 +755,9 @@ def compute_asymptotic_mixing_length(
                 zlup = zlup + dz
                 if bsum >= tke:
                     if ptem >= 0.0:
-                        tem2 = max(ptem, pblcons.ZFMIN)
+                        tem2 = max(ptem, pbl_constants.ZFMIN)
                     else:
-                        tem2 = min(ptem, -pblcons.ZFMIN)
+                        tem2 = min(ptem, -pbl_constants.ZFMIN)
                     ptem1 = (bsum - tke) / tem2
                     zlup = zlup - ptem1 * dz
                     zlup = max(zlup, 0.0)
@@ -754,7 +773,8 @@ def compute_asymptotic_mixing_length(
                 if k_mask[0, 0, 0] + lev == 0:
                     dz = zl[0, 0, lev]
                     tem1 = tsea * (
-                        1.0 + constants.ZVIR * max(q1_0[0, 0, lev], pblcons.PBL_QMIN)
+                        1.0
+                        + constants.ZVIR * max(q1_0[0, 0, lev], pbl_constants.PBL_QMIN)
                     )
                 else:
                     dz = zl[0, 0, lev] - zl[0, 0, lev - 1]
@@ -764,9 +784,9 @@ def compute_asymptotic_mixing_length(
                 zldn = zldn + dz
                 if bsum >= tke:
                     if ptem >= 0.0:
-                        tem2 = max(ptem, pblcons.ZFMIN)
+                        tem2 = max(ptem, pbl_constants.ZFMIN)
                     else:
-                        tem2 = min(ptem, -pblcons.ZFMIN)
+                        tem2 = min(ptem, -pbl_constants.ZFMIN)
                     ptem1 = (bsum - tke) / tem2
                     zldn = zldn - ptem1 * dz
                     zldn = max(zldn, 0.0)
@@ -774,26 +794,26 @@ def compute_asymptotic_mixing_length(
             lev -= 1
 
         tem = 0.5 * (zi[0, 0, 1] - zi)
-        tem1 = min(tem, pblcons.RLMN)
+        tem1 = min(tem, pbl_constants.RLMN)
 
         ptem2 = min(zlup, zldn)
-        rlam = pblcons.ELMFAC * ptem2
+        rlam = pbl_constants.ELMFAC * ptem2
         rlam = max(rlam, tem1)
-        rlam = min(rlam, pblcons.RLMX)
+        rlam = min(rlam, pbl_constants.RLMX)
 
         ptem2 = sqrt(zlup * zldn)
-        ele = pblcons.ELEFAC * ptem2
+        ele = pbl_constants.ELEFAC * ptem2
         ele = max(ele, tem1)
-        ele = min(ele, pblcons.ELMX)
+        ele = min(ele, pbl_constants.ELMX)
 
     with computation(FORWARD):
         with interval(0, -1):
             if zol < 0.0:
-                zk = pblcons.VK * zl * (1.0 - 100.0 * zol) ** 0.2
+                zk = pbl_constants.VK * zl * (1.0 - 100.0 * zol) ** 0.2
             elif zol >= 1.0:
-                zk = pblcons.VK * zl / 3.7
+                zk = pbl_constants.VK * zl / 3.7
             else:
-                zk = pblcons.VK * zl / (1.0 + 2.7 * zol)
+                zk = pbl_constants.VK * zl / (1.0 + 2.7 * zol)
 
             elm = zk * rlam / (rlam + zk)
             dz = zi[0, 0, 1] - zi
@@ -850,7 +870,7 @@ def compute_eddy_diffusivity_buoy_shear(
     with computation(PARALLEL), interval(0, -1):
         tem = 0.5 * (elm[0, 0, 0] + elm[0, 0, 1])
         tem = tem * sqrt(0.5 * (tke[0, 0, 0] + tke[0, 0, 1]))
-        ri = max(bf[0, 0, 0] / shr2[0, 0, 0], pblcons.RIMIN)
+        ri = max(bf[0, 0, 0] / shr2[0, 0, 0], pbl_constants.RIMIN)
 
         if k_mask[0, 0, 0] < kpbl[0, 0]:
             if pblflg[0, 0]:
@@ -861,33 +881,33 @@ def compute_eddy_diffusivity_buoy_shear(
                 dku = dkt[0, 0, 0] * prn[0, 0, 0]
         else:
             if ri < 0.0:  # Unstable regime
-                dku = pblcons.CK1 * tem
-                dkt = pblcons.RCHCK * dku[0, 0, 0]
+                dku = pbl_constants.CK1 * tem
+                dkt = pbl_constants.RCHCK * dku[0, 0, 0]
             else:  # Stable regime
-                dkt = pblcons.CH1 * tem
-                dku = dkt[0, 0, 0] * min(1.0 + 2.1 * ri, pblcons.PRMAX)
+                dkt = pbl_constants.CH1 * tem
+                dku = dkt[0, 0, 0] * min(1.0 + 2.1 * ri, pbl_constants.PRMAX)
 
         tem = ckz[0, 0, 0] * tem
         dku_tmp = max(dku[0, 0, 0], tem)
-        dkt_tmp = max(dkt[0, 0, 0], tem / pblcons.PRSCU)
+        dkt_tmp = max(dkt[0, 0, 0], tem / pbl_constants.PRSCU)
 
         if scuflg[0, 0]:
             if k_mask[0, 0, 0] >= mrad[0, 0] and k_mask[0, 0, 0] < krad[0, 0]:
                 dku = dku_tmp
                 dkt = dkt_tmp
 
-        dkq = pblcons.PRTKE * dkt[0, 0, 0]
+        dkq = pbl_constants.PRTKE * dkt[0, 0, 0]
 
-        dkt = max(min(dkt[0, 0, 0], pblcons.DKMAX), xkzo[0, 0, 0])
+        dkt = max(min(dkt[0, 0, 0], pbl_constants.DKMAX), xkzo[0, 0, 0])
 
-        dkq = max(min(dkq[0, 0, 0], pblcons.DKMAX), xkzo[0, 0, 0])
+        dkq = max(min(dkq[0, 0, 0], pbl_constants.DKMAX), xkzo[0, 0, 0])
 
-        dku = max(min(dku[0, 0, 0], pblcons.DKMAX), xkzmo[0, 0, 0])
+        dku = max(min(dku[0, 0, 0], pbl_constants.DKMAX), xkzmo[0, 0, 0])
 
     with computation(PARALLEL), interval(...):
         if k_mask[0, 0, 0] == krad[0, 0]:
             if scuflg[0, 0]:
-                tem1 = max(bf[0, 0, 0] / gotvx[0, 0, 0], pblcons.TDZMIN)
+                tem1 = max(bf[0, 0, 0] / gotvx[0, 0, 0], pbl_constants.TDZMIN)
                 ptem = radj[0, 0] / tem1
                 dkt = dkt[0, 0, 0] + ptem
                 dku = dku[0, 0, 0] + ptem
@@ -920,7 +940,7 @@ def compute_eddy_diffusivity_buoy_shear(
 
             buop = 0.5 * (gotvx[0, 0, 0] * sflux[0, 0] + (tem + ptem))
 
-            tem2 = stress * ustar * phim / (pblcons.VK * zl)
+            tem2 = stress * ustar * phim / (pbl_constants.VK * zl)
             shrp = 0.5 * (dku[0, 0, 0] * shr2[0, 0, 0] + ptem1 + ptem2 + tem2)
 
             prod = buop + shrp
@@ -1003,7 +1023,7 @@ def predict_tke(
     from __externals__ import dtn, kk
 
     with computation(PARALLEL), interval(...):
-        rle = pblcons.CE0 / ele[0, 0, 0]
+        rle = pbl_constants.CE0 / ele[0, 0, 0]
 
     with computation(PARALLEL), interval(...):
         n = 0
@@ -1016,7 +1036,8 @@ def predict_tke(
                 0.0,
             )
             tke = max(
-                tke[0, 0, 0] + dtn * (prod[0, 0, 0] - diss[0, 0, 0]), pblcons.TKMIN
+                tke[0, 0, 0] + dtn * (prod[0, 0, 0] - diss[0, 0, 0]),
+                pbl_constants.TKMIN,
             )
             n = n + 1
 
@@ -1148,7 +1169,7 @@ def recover_tke_tendency(
     from __externals__ import ntke, rdt
 
     with computation(PARALLEL), interval(...):
-        f1 = max(f1, pblcons.TKMIN)
+        f1 = max(f1, pbl_constants.TKMIN)
         qtend = (f1[0, 0, 0] - q1[0, 0, 0][ntke]) * rdt
         rtg[0, 0, 0][ntke] = rtg[0, 0, 0][ntke] + qtend
 
@@ -1409,7 +1430,9 @@ def moment_tridiag_mat_ele_comp(
 
     with computation(PARALLEL), interval(0, -1):
         if dspheat:
-            tdt = tdt[0, 0, 0] + pblcons.DSPFAC * (diss[0, 0, 0] / constants.CP_AIR)
+            tdt = tdt[0, 0, 0] + pbl_constants.DSPFAC * (
+                diss[0, 0, 0] / constants.CP_AIR
+            )
 
     with computation(FORWARD), interval(0, 1):
         ad = 1.0 + dtdz1[0, 0] * stress[0, 0] / spd1[0, 0]
@@ -1562,7 +1585,7 @@ class ScaleAwareTKEMoistEDMF:
 
         self._dt_atmos = config.dt_atmos
         self._rdt = 1.0 / self._dt_atmos
-        self._kk = max(round(self._dt_atmos / pblcons.CDTN), 1)
+        self._kk = max(round(self._dt_atmos / pbl_constants.CDTN), 1)
         self._dtn = self._dt_atmos / float(self._kk)
 
         self._area = grid_area

--- a/tests/integration/test_all.py
+++ b/tests/integration/test_all.py
@@ -72,7 +72,7 @@ def states_from_fortran_restarts(
     quantity_factory: QuantityFactory,
     qf_sfc: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/integration/test_gfdl_cld_mp.py
+++ b/tests/integration/test_gfdl_cld_mp.py
@@ -57,7 +57,7 @@ def states_from_fortran_restarts(
     ak: Quantity,
     quantity_factory: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/integration/test_gfs_mp.py
+++ b/tests/integration/test_gfs_mp.py
@@ -56,7 +56,7 @@ def states_from_fortran_restarts(
     ak: Quantity,
     quantity_factory: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/integration/test_radiation_driver.py
+++ b/tests/integration/test_radiation_driver.py
@@ -95,7 +95,7 @@ def states_from_fortran_restarts(
     tracer_datafile: Path,
     ak: Quantity,
     quantity_factory: QuantityFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     dycore_data = xr.open_dataset(dycore_datafile)
     phys_data = xr.open_dataset(phys_datafile)

--- a/tests/integration/test_samfshalconv.py
+++ b/tests/integration/test_samfshalconv.py
@@ -57,7 +57,7 @@ def states_from_fortran_restarts(
     ak: Quantity,
     quantity_factory: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/integration/test_satmedmf.py
+++ b/tests/integration/test_satmedmf.py
@@ -57,7 +57,7 @@ def states_from_fortran_restarts(
     ak: Quantity,
     quantity_factory: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -40,7 +40,7 @@ def states_from_fortran_restarts(
     quantity_factory: QuantityFactory,
     qf_sfc: QuantityFactory,
     stencil_factory: StencilFactory,
-    schemes: PHYSICS_PACKAGES,
+    schemes: list[PHYSICS_PACKAGES],
 ):
     pk0inv = (1.0 / physcons.P00) ** constants.KAPPA
     dycore_data = xr.open_dataset(dycore_datafile)

--- a/tests/savepoint/translate/translate_pbl_subtests.py
+++ b/tests/savepoint/translate/translate_pbl_subtests.py
@@ -1,6 +1,5 @@
 from gt4py.cartesian.gtscript import FORWARD, computation, interval
 
-import pyshield.constants as physcons
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import (
@@ -15,6 +14,7 @@ from ndsl.dsl.typing import (
 from ndsl.stencils.basic_operations import copy
 from pyshield._config import TRACER_DIM, FloatFieldTracer
 from pyshield.stencils.pbl import PBLConfig
+from pyshield.stencils.pbl import constants as pbl_constants
 from pyshield.stencils.pbl.mfpblt import PBLMassFlux
 from pyshield.stencils.pbl.mfscu import StratocumulusMassFlux
 from pyshield.stencils.pbl.satmedmfvdiff import (
@@ -807,7 +807,7 @@ class TKEPredict:
     ):
         idx = stencil_factory.grid_indexing
         self._dt_atmos = config.dt_atmos
-        self._kk = max(round(self._dt_atmos / physcons.CDTN), 1)
+        self._kk = max(round(self._dt_atmos / pbl_constants.CDTN), 1)
         self._dtn = self._dt_atmos / float(self._kk)
 
         self._predict_tke = stencil_factory.from_origin_domain(
@@ -1876,7 +1876,7 @@ class Half2:
 
         self._dt_atmos = config.dt_atmos
         self._rdt = 1.0 / self._dt_atmos
-        self._kk = max(round(self._dt_atmos / physcons.CDTN), 1)
+        self._kk = max(round(self._dt_atmos / pbl_constants.CDTN), 1)
         self._dtn = self._dt_atmos / float(self._kk)
 
         self._ntiw = config.ntiw
@@ -2539,7 +2539,7 @@ class SCUEnd:
 
         self._dt_atmos = config.dt_atmos
         self._rdt = 1.0 / self._dt_atmos
-        self._kk = max(round(self._dt_atmos / physcons.CDTN), 1)
+        self._kk = max(round(self._dt_atmos / pbl_constants.CDTN), 1)
         self._dtn = self._dt_atmos / float(self._kk)
 
         self._ntiw = config.ntiw


### PR DESCRIPTION
**Description**

This PR re-enables `mypy` (not only for the source code directory) in  `pyshield` and fixes all the errors reported. This is a follow-up from #81 and explains the pyshield-side of failures in https://github.com/NOAA-GFDL/pace/pull/173 and why we haven't seen them before.

<!--
It then fixes the obvious issues and leaves two things to discuss:

1. In `PBLConfig`, should `dt_atmos` be of type `int` (as type-hinted now) or is it supposed to be a `float` (like other usage of `dt_atmos` would suggest?
2. `translate_pbl_subtests` is claiming that `pyshield.constants` contains a constant called `CDTN`, where such a constant doesn't exist. Should that one be imported from `pyshield.stencils.pbl.constants`?

@oelbert I guess you are the expert here. What do you think about the question above?
-->

**How Has This Been Tested?**

All good once CI is green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
  See inline comments
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
