### PR TITLE
Pin pySHiELD to NDSL version 2026.01.00

### DIFF
--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -122,6 +122,7 @@
     "    layout=layout,\n",
     "    tile_partitioner=partitioner.tile,\n",
     "    tile_rank=cs_communicator.tile.rank,\n",
+    "    backend=backend,\n",
     ")\n",
     "\n",
     "# useful for easily allocating distributed data storages (fields)\n",

--- a/examples/notebook/test_rad.ipynb
+++ b/examples/notebook/test_rad.ipynb
@@ -88,6 +88,7 @@
    "outputs": [],
    "source": [
     "rank = 0\n",
+    "backend = \"numpy\"\n",
     "\n",
     "comm = NullComm(rank, 1)\n",
     "communicator = TileCommunicator.from_layout(comm=comm, layout=(1,1))\n",
@@ -101,8 +102,9 @@
     "    layout=(1,1),\n",
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
+    "    backend=backend\n",
     ")\n",
-    "quantity_factory = QuantityFactory(sizer, backend=\"numpy\")"
+    "quantity_factory = QuantityFactory(sizer, backend=backend)"
    ]
   },
   {

--- a/examples/notebook/test_raddriver.ipynb
+++ b/examples/notebook/test_raddriver.ipynb
@@ -74,6 +74,7 @@
    "outputs": [],
    "source": [
     "rank = 0\n",
+    "backend = \"numpy\"\n",
     "\n",
     "comm = NullComm(rank, 1)\n",
     "communicator = TileCommunicator.from_layout(comm=comm, layout=(1,1))\n",
@@ -87,8 +88,9 @@
     "    layout=(1,1),\n",
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
+    "    backend=backend\n",
     ")\n",
-    "quantity_factory = QuantityFactory(sizer, backend=\"numpy\")"
+    "quantity_factory = QuantityFactory(sizer, backend=backend)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[dev]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.01.00"]
 pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/PyFV3.git@develop"]
 test = [
   "pytest",

--- a/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
@@ -899,7 +899,7 @@ class GFDLCloudMicrophysics:
         self._convert_mm_day = 86400.0 * constants.RGRAV / self.config.dt_split
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            basic.copy_defn,
+            basic.copy,
             origin=self._idx.origin_compute(),
             domain=self._idx.domain_compute(),
         )

--- a/pyshield/stencils/gfdl_cld_microphysics/terminal_fall.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/terminal_fall.py
@@ -7,7 +7,7 @@ from ndsl import GridIndexing, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, IntFieldIJ
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyfv3.stencils.remap_profile import RemapProfile
 from pyshield.stencils.gfdl_cld_microphysics._config import GFDLCloudMPConfig
 
@@ -407,7 +407,7 @@ class TerminalFall:
         # compile stencils
 
         self._copy_stencil = stencil_factory.from_dims_halo(
-            copy_defn,
+            copy,
             compute_dims=dims,
         )
 

--- a/pyshield/stencils/physics.py
+++ b/pyshield/stencils/physics.py
@@ -21,7 +21,7 @@ from ndsl.dsl.typing import (
 )
 from ndsl.grid import GridData
 from ndsl.logging import ndsl_log
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyshield._config import (
     PHYSICS_PACKAGES,
     TRACER_DIM,
@@ -1242,7 +1242,7 @@ class Physics:
         self._sfcvisdfd = make_quantity_2d()
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            func=copy_defn,
+            func=copy,
             origin=grid_indexing.origin_full(),
             domain=grid_indexing.domain_full(add=(0, 0, 1)),
         )

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -112,8 +112,8 @@ def states_from_fortran_restarts(
 
 def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
     n_halo = 3
-
     rank = 0
+    backend = "numpy"
 
     comm = NullComm(rank, 1)
     communicator = TileCommunicator.from_layout(comm=comm, layout=(1, 1))
@@ -127,8 +127,9 @@ def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
         layout=(1, 1),
         tile_partitioner=communicator.partitioner.tile,
         tile_rank=communicator.tile.rank,
+        backend=backend,
     )
-    quantity_factory = QuantityFactory(sizer, backend="numpy")
+    quantity_factory = QuantityFactory(sizer, backend=backend)
 
     soil_sizer = SubtileGridSizer.from_tile_params(
         nx_tile=nx,
@@ -139,6 +140,7 @@ def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
         layout=(1, 1),
         tile_partitioner=communicator.partitioner.tile,
         tile_rank=communicator.tile.rank,
+        backend=backend,
     )
     qf_soil = QuantityFactory(soil_sizer, backend="numpy")
 

--- a/tests/savepoint/translate/translate_atmos_phy_statein.py
+++ b/tests/savepoint/translate/translate_atmos_phy_statein.py
@@ -58,6 +58,7 @@ class TranslateAtmosPhysDriverStatein(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_cloud_frac.py
+++ b/tests/savepoint/translate/translate_cloud_frac.py
@@ -344,6 +344,7 @@ class TranslateCloudFrac(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_cumulative_shalconv.py
+++ b/tests/savepoint/translate/translate_cumulative_shalconv.py
@@ -3403,6 +3403,7 @@ class TranslateInitCol(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -3516,6 +3517,7 @@ class TranslateStatic1(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -3621,6 +3623,7 @@ class TranslateStatic2(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -3738,6 +3741,7 @@ class TranslateUpdateKb9(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -3851,6 +3855,7 @@ class TranslateStatic10(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -4018,6 +4023,7 @@ class TranslateStatic11(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -4183,6 +4189,7 @@ class TranslateStatic12(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -4318,6 +4325,7 @@ class TranslateFeedbackCtrl(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -4379,6 +4387,7 @@ class TranslateSC13(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -4533,6 +4542,7 @@ class TranslateCompTendencies(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_final_mp.py
+++ b/tests/savepoint/translate/translate_final_mp.py
@@ -1034,6 +1034,7 @@ class TranslateFinalCalculations(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -1491,6 +1492,7 @@ class TranslatePostMP(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_gfdl_cld_microphysics.py
+++ b/tests/savepoint/translate/translate_gfdl_cld_microphysics.py
@@ -328,6 +328,7 @@ class TranslateMicrophysics3(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_gfs_physics_driver.py
+++ b/tests/savepoint/translate/translate_gfs_physics_driver.py
@@ -127,6 +127,7 @@ class TranslateGFSPhysicsDriver(TranslatePhysicsFortranData2Py):
             nz=self.config.npz,
             n_halo=3,
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_mfpblt.py
+++ b/tests/savepoint/translate/translate_mfpblt.py
@@ -62,6 +62,7 @@ class TranslateMFPBLT(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_mfscu.py
+++ b/tests/savepoint/translate/translate_mfscu.py
@@ -65,6 +65,7 @@ class TranslateMFSCU(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_microphysics.py
+++ b/tests/savepoint/translate/translate_microphysics.py
@@ -79,6 +79,7 @@ class TranslateMicroph(TranslatePhysicsFortranData2Py):
             nz=self.config.npz,
             n_halo=3,
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_mp_full.py
+++ b/tests/savepoint/translate/translate_mp_full.py
@@ -466,6 +466,7 @@ class TranslateMPFull(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -695,6 +696,7 @@ class TranslateMPSub(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_particle_properties.py
+++ b/tests/savepoint/translate/translate_particle_properties.py
@@ -500,6 +500,7 @@ class TranslateParticleProperties(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_pbl.py
+++ b/tests/savepoint/translate/translate_pbl.py
@@ -97,6 +97,7 @@ class TranslatePBL(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_pbl_subtests.py
+++ b/tests/savepoint/translate/translate_pbl_subtests.py
@@ -12,7 +12,7 @@ from ndsl.dsl.typing import (
     Int,
     IntFieldIJ,
 )
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyshield._config import TRACER_DIM, FloatFieldTracer
 from pyshield.stencils.pbl import PBLConfig
 from pyshield.stencils.pbl.mfpblt import PBLMassFlux
@@ -1345,7 +1345,7 @@ class TKETendencyCalc:
         )
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            func=copy_defn,
+            func=copy,
             origin=idx.origin_compute(),
             domain=idx.domain_compute(),
         )
@@ -3329,6 +3329,7 @@ class TranslatePBLInit(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3437,6 +3438,7 @@ class TranslateMRF(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3504,6 +3506,7 @@ class TranslateThermalPBL(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3560,6 +3563,7 @@ class TranslateStratocumulus(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3630,6 +3634,7 @@ class TranslatePBLAML(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3703,6 +3708,7 @@ class TranslateTKETridiagEle(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3761,6 +3767,7 @@ class TranslatePrandtl(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3909,6 +3916,7 @@ class TranslateEdDiffShear(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -3970,6 +3978,7 @@ class TranslateUpDownTKE(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4064,6 +4073,7 @@ class TranslateMomentTridiagComp(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4146,6 +4156,7 @@ class TranslateHeatTracerTridiagEle(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4212,6 +4223,7 @@ class TranslateTKETendencyCalc(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4295,6 +4307,7 @@ class TranslateHeatTracerTendencyCalc(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4383,6 +4396,7 @@ class TranslateMomentTendencyCalc(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4604,6 +4618,7 @@ class TranslateHalf2(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -4845,6 +4860,7 @@ class TranslateSCUEnd(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_preliminary_mp.py
+++ b/tests/savepoint/translate/translate_preliminary_mp.py
@@ -39,7 +39,7 @@ class PrelimCalcs:
         self._bottom_density = make_quantity2d()
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            basic.copy_defn,
+            basic.copy,
             origin=self._idx.origin_compute(),
             domain=self._idx.domain_compute(),
         )
@@ -572,6 +572,7 @@ class TranslatePreliminaryCalculations(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_samfshalconv.py
+++ b/tests/savepoint/translate/translate_samfshalconv.py
@@ -79,6 +79,7 @@ class TranslateShalConv(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -95,6 +96,7 @@ class TranslateShalConv(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)

--- a/tests/savepoint/translate/translate_sedimentation.py
+++ b/tests/savepoint/translate/translate_sedimentation.py
@@ -695,6 +695,7 @@ class TranslateSedimentation(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(
@@ -875,6 +876,7 @@ class TranslateSediMelt(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_terminal_fall.py
+++ b/tests/savepoint/translate/translate_terminal_fall.py
@@ -135,6 +135,7 @@ class TranslateTerminalFall(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_tracer_sedi.py
+++ b/tests/savepoint/translate/translate_tracer_sedi.py
@@ -718,6 +718,7 @@ class TranslateTracerSed(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         self.quantity_factory = QuantityFactory(

--- a/tests/savepoint/translate/translate_tridiag.py
+++ b/tests/savepoint/translate/translate_tridiag.py
@@ -3,7 +3,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyshield._config import TRACER_DIM, FloatFieldTracer
 from pyshield.stencils.pbl.tridiag import tridi2, tridin, tridit
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
@@ -40,7 +40,7 @@ class TridiT:
             domain=idx.domain_compute(),
         )
         self._copy_stencil = stencil_factory.from_origin_domain(
-            func=copy_defn,
+            func=copy,
             origin=idx.origin_compute(),
             domain=idx.domain_compute(),
         )
@@ -83,7 +83,7 @@ class Tridi2:
         )
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            func=copy_defn,
+            func=copy,
             origin=idx.origin_compute(),
             domain=idx.domain_compute(),
         )
@@ -156,7 +156,7 @@ class TridiN:
         )
 
         self._copy_stencil = stencil_factory.from_origin_domain(
-            func=copy_defn,
+            func=copy,
             origin=idx.origin_compute(),
             domain=idx.domain_compute(),
         )
@@ -227,6 +227,7 @@ class TranslateTridit(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
@@ -268,6 +269,7 @@ class TranslateTridi2(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
         compute_func = Tridi2(self.stencil_factory, quantity_factory)
@@ -307,9 +309,9 @@ class TranslateTridin(TranslatePhysicsFortranData2Py):
             n_halo=3,
             data_dimensions={},
             layout=self.config.layout,
+            backend=self.stencil_factory.backend,
         )
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
-        config = self.config.pbl
         compute_func = TridiN(self.stencil_factory, quantity_factory, 8)
 
         compute_func(**inputs)


### PR DESCRIPTION
**Description**

This PR pins pySHiELD to NDSL version 2026.01.00 (as discussed in the last NASA/NOAA sync) and updates code to remove any deprecation warnings that would come with the update.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
