### PR TITLE
[Update] NDSL 2026.02.00 breaking change & update to DaCe V2

### DIFF
--- a/.github/workflows/create_cache.yaml
+++ b/.github/workflows/create_cache.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       # Only restore (don't save) caches on PRs. New caches created from PRs won't be
       # accessible from other PRs, see workflows/create_cache.yaml.

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_unit_tests:
-    uses: floriandeconinck/pace/.github/workflows/main_unit_tests.yaml@update/2026.02.00
+    uses: romanc/pace/.github/workflows/main_unit_tests.yaml@noop
     with:
       component_trigger: true
       component_name: pySHiELD

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_unit_tests:
-    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
+    uses: floriandeconinck/pace/.github/workflows/main_unit_tests.yaml@update/2026.02.00
     with:
       component_trigger: true
       component_name: pySHiELD

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -44,9 +44,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          repository: NOAA-GFDL/PySHiELD
+          repository: FlorianDeconinck/PySHiELD
+          ref: update/2026.02.00
           path: pySHiELD
-          ref: develop
 
       - name: 'Setup Python ${{ inputs.python_version && inputs.python_version || env.python_default }}'
         uses: actions/setup-python@v6

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -36,7 +36,7 @@ jobs:
     env:
       TEST_DATA_PATH: "./test_data/8.1.3/c12_6ranks_baroclinic/physics"
       TEST_DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_baroclinic.physics.tar.gz"
-      python_default: '3.11'
+      python_default: '3.12'
 
     steps:
       - name: External trigger Checkout pySHiELD
@@ -44,8 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          repository: FlorianDeconinck/PySHiELD
-          ref: update/2026.02.00
+          repository: NOAA-GFDL/pySHiELD
           path: pySHiELD
 
       - name: 'Setup Python ${{ inputs.python_version && inputs.python_version || env.python_default }}'

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -115,7 +115,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pySHiELD
           pytest \
             -v -s --data_path=${{ env.TEST_DATA_PATH }} \
-            --backend=numpy \
+            --backend=st:numpy:cpu:IJK \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
             ./tests/savepoint
 
@@ -128,6 +128,6 @@ jobs:
           export NDSL_LOGLEVEL=Debug
           pytest \
             -vvv -x -s --data_path=${{ env.TEST_DATA_PATH }} \
-            --backend=dace:cpu \
+            --backend=orch:dace:cpu:KJI \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
             ./tests/savepoint

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -128,6 +128,6 @@ jobs:
           export NDSL_LOGLEVEL=Debug
           pytest \
             -vvv -x -s --data_path=${{ env.TEST_DATA_PATH }} \
-            --backend=orch:dace:cpu:KJI \
+            --backend=orch:dace:cpu:KIJ \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
             ./tests/savepoint

--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -100,7 +100,7 @@
     "    TilePartitioner,\n",
     "    WrappedHaloUpdater,\n",
     ")\n",
-    "from ndsl.constants import X_DIM, Y_DIM, Z_DIM \n",
+    "from ndsl.constants import I_DIM, J_DIM, K_DIM \n",
     "from ndsl.typing import Communicator "
    ]
   },
@@ -166,8 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qq = quantity_factory.ones(dims=(X_DIM, Y_DIM, Z_DIM), units=\"none\", dtype=\"float\")\n",
-    "qt = quantity_factory.ones(dims=(X_DIM, Y_DIM, Z_DIM), units=\"none\", dtype=\"float\")\n",
+    "qq = quantity_factory.ones(dims=(I_DIM, J_DIM, K_DIM), units=\"none\", dtype=\"float\")\n",
+    "qt = quantity_factory.ones(dims=(I_DIM, J_DIM, K_DIM), units=\"none\", dtype=\"float\")\n",
     "qt.view[:] *= 0.2\n",
     "dt = 0.5\n",
     "\n",

--- a/examples/notebook/utilities.py
+++ b/examples/notebook/utilities.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from ndsl import NullComm, Quantity, QuantityFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -95,7 +96,7 @@ def fortran_restart_to_radstate(
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, etafile: Path, backend: str = "numpy"
+    nx: int, ny: int, nz: int, etafile: Path, backend: Backend = backend_python
 ):
     nhalo = 3
     stencil_factory, quantity_factory = get_factories_single_tile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[dev]"
 ]
-ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@feature/NDSL_Backend"]
-pyfv3 = ["pyfv3 @ git+https://github.com/floriandeconinck/PyFV3.git@update/2026.02.00"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.02.00"]
+pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
 test = [
   "pytest",
   "pytest-subtests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ extras = [
   "pyshield[dev]"
 ]
 ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@feature/NDSL_Backend"]
-pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/PyFV3.git@develop"]
+pyfv3 = ["pyfv3 @ git+https://github.com/floriandeconinck/PyFV3.git@update/2026.02.00"]
 test = [
   "pytest",
   "pytest-subtests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[dev]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.01.00"]
+ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@feature/NDSL_Backend"]
 pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/PyFV3.git@develop"]
 test = [
   "pytest",

--- a/pyshield/physics_state.py
+++ b/pyshield/physics_state.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.typing import Float
 from pyshield._config import PHYSICS_PACKAGES
 from pyshield.stencils.gfs_microphysics import GFSMicrophysicsState
@@ -16,14 +16,14 @@ class PhysicsState:
     qvapor: Quantity = field(
         metadata={
             "name": "specific_humidity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
         }
     )
     qliquid: Quantity = field(
         metadata={
             "name": "cloud_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -31,7 +31,7 @@ class PhysicsState:
     qice: Quantity = field(
         metadata={
             "name": "cloud_ice_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -39,7 +39,7 @@ class PhysicsState:
     qrain: Quantity = field(
         metadata={
             "name": "rain_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -47,7 +47,7 @@ class PhysicsState:
     qsnow: Quantity = field(
         metadata={
             "name": "snow_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -55,7 +55,7 @@ class PhysicsState:
     qgraupel: Quantity = field(
         metadata={
             "name": "graupel_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -63,7 +63,7 @@ class PhysicsState:
     qo3mr: Quantity = field(
         metadata={
             "name": "ozone_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -71,7 +71,7 @@ class PhysicsState:
     qsgs_tke: Quantity = field(
         metadata={
             "name": "turbulent_kinetic_energy",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m**2/s**2",
             "intent": "inout",
         }
@@ -79,7 +79,7 @@ class PhysicsState:
     qcld: Quantity = field(
         metadata={
             "name": "cloud_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -87,7 +87,7 @@ class PhysicsState:
     pt: Quantity = field(
         metadata={
             "name": "air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "inout",
         }
@@ -95,7 +95,7 @@ class PhysicsState:
     delp: Quantity = field(
         metadata={
             "name": "pressure_thickness_of_atmospheric_layer",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "inout",
         }
@@ -103,7 +103,7 @@ class PhysicsState:
     delz: Quantity = field(
         metadata={
             "name": "vertical_thickness_of_atmospheric_layer",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -111,7 +111,7 @@ class PhysicsState:
     ua: Quantity = field(
         metadata={
             "name": "eastward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -119,14 +119,14 @@ class PhysicsState:
     va: Quantity = field(
         metadata={
             "name": "northward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
         }
     )
     w: Quantity = field(
         metadata={
             "name": "vertical_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -134,7 +134,7 @@ class PhysicsState:
     omga: Quantity = field(
         metadata={
             "name": "vertical_pressure_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa/s",
             "intent": "inout",
         }
@@ -142,14 +142,14 @@ class PhysicsState:
     physics_updated_specific_humidity: Quantity = field(
         metadata={
             "name": "physics_updated_specific_humidity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
         }
     )
     physics_updated_qliquid: Quantity = field(
         metadata={
             "name": "physics_updated_liquid_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -157,7 +157,7 @@ class PhysicsState:
     physics_updated_qice: Quantity = field(
         metadata={
             "name": "physics_updated_ice_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -165,7 +165,7 @@ class PhysicsState:
     physics_updated_qrain: Quantity = field(
         metadata={
             "name": "physics_updated_rain_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -173,7 +173,7 @@ class PhysicsState:
     physics_updated_qsnow: Quantity = field(
         metadata={
             "name": "physics_updated_snow_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -181,7 +181,7 @@ class PhysicsState:
     physics_updated_qgraupel: Quantity = field(
         metadata={
             "name": "physics_updated_graupel_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -189,7 +189,7 @@ class PhysicsState:
     physics_updated_qo3mr: Quantity = field(
         metadata={
             "name": "physics_updated_ozone_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -197,7 +197,7 @@ class PhysicsState:
     physics_updated_qtke: Quantity = field(
         metadata={
             "name": "physics_updated_tke_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -205,7 +205,7 @@ class PhysicsState:
     physics_updated_cloud_fraction: Quantity = field(
         metadata={
             "name": "physics_cloud_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -213,7 +213,7 @@ class PhysicsState:
     physics_updated_pt: Quantity = field(
         metadata={
             "name": "physics_air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "inout",
         }
@@ -221,7 +221,7 @@ class PhysicsState:
     physics_updated_ua: Quantity = field(
         metadata={
             "name": "physics_eastward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -229,7 +229,7 @@ class PhysicsState:
     physics_updated_va: Quantity = field(
         metadata={
             "name": "physics_northward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -237,7 +237,7 @@ class PhysicsState:
     delprsi: Quantity = field(
         metadata={
             "name": "model_level_pressure_thickness_in_physics",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "inout",
         }
@@ -245,7 +245,7 @@ class PhysicsState:
     phii: Quantity = field(
         metadata={
             "name": "interface_geopotential_height",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -253,7 +253,7 @@ class PhysicsState:
     phil: Quantity = field(
         metadata={
             "name": "layer_geopotential_height",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -261,7 +261,7 @@ class PhysicsState:
     dz: Quantity = field(
         metadata={
             "name": "geopotential_height_thickness",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -269,7 +269,7 @@ class PhysicsState:
     wmp: Quantity = field(
         metadata={
             "name": "layer_mean_vertical_velocity_microph",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -277,7 +277,7 @@ class PhysicsState:
     prsi: Quantity = field(
         metadata={
             "name": "interface_pressure",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "Pa",
             "intent": "inout",
         }
@@ -285,7 +285,7 @@ class PhysicsState:
     prsik: Quantity = field(
         metadata={
             "name": "log_interface_pressure",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -293,7 +293,7 @@ class PhysicsState:
     prslk: Quantity = field(
         metadata={
             "name": "Exner_function",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -301,7 +301,7 @@ class PhysicsState:
     pgr: Quantity = field(
         metadata={
             "name": "ground_pressure",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -309,7 +309,7 @@ class PhysicsState:
     hsw: Quantity = field(
         metadata={
             "name": "shortwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "k/s",
             "intent": "in",
         }
@@ -317,7 +317,7 @@ class PhysicsState:
     hlw: Quantity = field(
         metadata={
             "name": "longwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "k/s",
             "intent": "in",
         }
@@ -325,7 +325,7 @@ class PhysicsState:
     land: Quantity = field(
         metadata={
             "name": "land_mask",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "in",
         }
@@ -333,7 +333,7 @@ class PhysicsState:
     tsfc: Quantity = field(
         metadata={
             "name": "surface_temperature",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "K",
             "intent": "inout",
         }
@@ -341,7 +341,7 @@ class PhysicsState:
     flwu: Quantity = field(
         metadata={
             "name": "longwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "",
             "intent": "out",
         }
@@ -349,7 +349,7 @@ class PhysicsState:
     flwd: Quantity = field(
         metadata={
             "name": "longwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "",
             "intent": "out",
         }
@@ -357,7 +357,7 @@ class PhysicsState:
     fswu: Quantity = field(
         metadata={
             "name": "shortwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "",
             "intent": "out",
         }
@@ -365,7 +365,7 @@ class PhysicsState:
     fswd: Quantity = field(
         metadata={
             "name": "shortwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "",
             "intent": "out",
         }
@@ -373,7 +373,7 @@ class PhysicsState:
     hrtlw: Quantity = field(
         metadata={
             "name": "longwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "out",
         }
@@ -381,7 +381,7 @@ class PhysicsState:
     hrtsw: Quantity = field(
         metadata={
             "name": "shortwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "out",
         }
@@ -389,7 +389,7 @@ class PhysicsState:
     kpbl: Quantity = field(
         metadata={
             "name": "pbl_index",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "inout",
         }
@@ -397,7 +397,7 @@ class PhysicsState:
     kinver: Quantity = field(
         metadata={
             "name": "inversion_layer_index",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "inout",
         }
@@ -405,7 +405,7 @@ class PhysicsState:
     hpbl: Quantity = field(
         metadata={
             "name": "pbl_height",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -421,7 +421,7 @@ class PhysicsState:
         # storage for tendency variables not in PhysicsState
         if "GFS_microphysics" in [scheme.value for scheme in schemes]:
             tendency = quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 "unknown",
                 dtype=Float,
             )

--- a/pyshield/radiation/rte_rrtmgp.py
+++ b/pyshield/radiation/rte_rrtmgp.py
@@ -9,7 +9,7 @@ from pyrte_rrtmgp.rrtmgp_data_files import CloudOpticsFiles, GasOpticsFiles
 
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval, log
@@ -183,47 +183,47 @@ class RTE_RRTMGPDriver:
 
         # Allocate quantities
         self._coszdg = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "radians",
             dtype=Float,
         )
         self._daymask = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "",
             dtype=Bool,
         )
         self._co2_cyc = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "",
             dtype=Bool,
         )
         self._co2_arr = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "",
             dtype=Bool,
         )
         self._tvly = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             "degK",
             dtype=Float,
         )
         self._tsfca = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "degK",
             dtype=Float,
         )
         self._cnvw = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             "",
             dtype=Float,
         )
         self._cnvc = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             "",
             dtype=Float,
         )
         self._coslat = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             "",
             dtype=Float,
         )

--- a/pyshield/radiation/state.py
+++ b/pyshield/radiation/state.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.typing import Float
 from ndsl.types import NumpyModule
 
@@ -15,7 +15,7 @@ class RTE_RRTMGPState:
     prsi: Quantity = field(
         metadata={
             "name": "interface_pressure",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -23,7 +23,7 @@ class RTE_RRTMGPState:
     prsl: Quantity = field(
         metadata={
             "name": "layer_pressure",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "inout",
         }
@@ -31,7 +31,7 @@ class RTE_RRTMGPState:
     tlyr: Quantity = field(
         metadata={
             "name": "layer_air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "in",
         }
@@ -39,7 +39,7 @@ class RTE_RRTMGPState:
     tlvl: Quantity = field(
         metadata={
             "name": "level_air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "degK",
             "intent": "inout",
         }
@@ -47,7 +47,7 @@ class RTE_RRTMGPState:
     tsfc: Quantity = field(
         metadata={
             "name": "surface_temperature",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "degK",
             "intent": "in",
         }
@@ -55,7 +55,7 @@ class RTE_RRTMGPState:
     mu0: Quantity = field(
         metadata={
             "name": "cosine_zenith_angle",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -63,7 +63,7 @@ class RTE_RRTMGPState:
     albedo: Quantity = field(
         metadata={
             "name": "surface_albedo",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -71,7 +71,7 @@ class RTE_RRTMGPState:
     sfc_emis: Quantity = field(
         metadata={
             "name": "surface_emissivity",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -79,7 +79,7 @@ class RTE_RRTMGPState:
     qvapor: Quantity = field(
         metadata={
             "name": "specific_humidity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "mol/mol",
             "intent": "in",
         }
@@ -87,7 +87,7 @@ class RTE_RRTMGPState:
     qliquid: Quantity = field(
         metadata={
             "name": "cloud_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "in",
         }
@@ -95,7 +95,7 @@ class RTE_RRTMGPState:
     qice: Quantity = field(
         metadata={
             "name": "cloud_ice_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "in",
         }
@@ -103,7 +103,7 @@ class RTE_RRTMGPState:
     qo3mr: Quantity = field(
         metadata={
             "name": "ozone_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "mol/mol",
             "intent": "in",
         }
@@ -111,7 +111,7 @@ class RTE_RRTMGPState:
     qcld: Quantity = field(
         metadata={
             "name": "cloud_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "in",
         }
@@ -119,7 +119,7 @@ class RTE_RRTMGPState:
     co2: Quantity = field(
         metadata={
             "name": "co2_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -127,7 +127,7 @@ class RTE_RRTMGPState:
     clwp: Quantity = field(
         metadata={
             "name": "cloud_liquid_water_path",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "g/m**2",
             "intent": "inout",
         }
@@ -135,7 +135,7 @@ class RTE_RRTMGPState:
     cip: Quantity = field(
         metadata={
             "name": "cloud_ice_path",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "g/m**2",
             "intent": "inout",
         }
@@ -143,7 +143,7 @@ class RTE_RRTMGPState:
     clwr: Quantity = field(
         metadata={
             "name": "cloud_liquid_water_radius",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "micron",
             "intent": "inout",
         }
@@ -151,7 +151,7 @@ class RTE_RRTMGPState:
     cir: Quantity = field(
         metadata={
             "name": "cloud_ice_radius",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "micron",
             "intent": "inout",
         }
@@ -159,7 +159,7 @@ class RTE_RRTMGPState:
     flwu: Quantity = field(
         metadata={
             "name": "longwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -167,7 +167,7 @@ class RTE_RRTMGPState:
     flwd: Quantity = field(
         metadata={
             "name": "longwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -175,7 +175,7 @@ class RTE_RRTMGPState:
     fswu: Quantity = field(
         metadata={
             "name": "shortwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -183,7 +183,7 @@ class RTE_RRTMGPState:
     fswd: Quantity = field(
         metadata={
             "name": "shortwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -191,7 +191,7 @@ class RTE_RRTMGPState:
     fswn: Quantity = field(
         metadata={
             "name": "net_sfc_shortwave_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -199,7 +199,7 @@ class RTE_RRTMGPState:
     flwu_clr: Quantity = field(
         metadata={
             "name": "clearsky_longwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -207,7 +207,7 @@ class RTE_RRTMGPState:
     flwd_clr: Quantity = field(
         metadata={
             "name": "clearsky_longwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -215,7 +215,7 @@ class RTE_RRTMGPState:
     fswu_clr: Quantity = field(
         metadata={
             "name": "clearsky_shortwave_flux_up",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -223,7 +223,7 @@ class RTE_RRTMGPState:
     fswd_clr: Quantity = field(
         metadata={
             "name": "clearsky_shortwave_flux_down",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -231,7 +231,7 @@ class RTE_RRTMGPState:
     hrtlw: Quantity = field(
         metadata={
             "name": "longwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK/s",
             "intent": "out",
         }
@@ -239,7 +239,7 @@ class RTE_RRTMGPState:
     hrtsw: Quantity = field(
         metadata={
             "name": "shortwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK/s",
             "intent": "out",
         }
@@ -247,7 +247,7 @@ class RTE_RRTMGPState:
     hrtlw_clr: Quantity = field(
         metadata={
             "name": "clearsky_longwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK/s",
             "intent": "out",
         }
@@ -255,7 +255,7 @@ class RTE_RRTMGPState:
     hrtsw_clr: Quantity = field(
         metadata={
             "name": "clearsky_shortwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK/s",
             "intent": "out",
         }

--- a/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_microphysics_state.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_microphysics_state.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field, fields
 from typing import Any, Dict, Mapping
 
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 
 
 @dataclass()
@@ -10,7 +10,7 @@ class GFDLCloudMicrophysicsState:
     qvapor: Quantity = field(
         metadata={
             "name": "specific_humidity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -18,7 +18,7 @@ class GFDLCloudMicrophysicsState:
     qliquid: Quantity = field(
         metadata={
             "name": "cloud_water_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -26,7 +26,7 @@ class GFDLCloudMicrophysicsState:
     qice: Quantity = field(
         metadata={
             "name": "cloud_ice_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -34,7 +34,7 @@ class GFDLCloudMicrophysicsState:
     qrain: Quantity = field(
         metadata={
             "name": "rain_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -42,7 +42,7 @@ class GFDLCloudMicrophysicsState:
     qsnow: Quantity = field(
         metadata={
             "name": "snow_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -50,7 +50,7 @@ class GFDLCloudMicrophysicsState:
     qgraupel: Quantity = field(
         metadata={
             "name": "graupel_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -58,7 +58,7 @@ class GFDLCloudMicrophysicsState:
     qcld: Quantity = field(
         metadata={
             "name": "cloud_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -66,7 +66,7 @@ class GFDLCloudMicrophysicsState:
     qcon: Quantity = field(
         metadata={
             "name": "condensate_mixing_ratio",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -74,7 +74,7 @@ class GFDLCloudMicrophysicsState:
     qcloud_cond_nuclei: Quantity = field(
         metadata={
             "name": "cloud_condensate_nuclei_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -82,7 +82,7 @@ class GFDLCloudMicrophysicsState:
     qcloud_ice_nuclei: Quantity = field(
         metadata={
             "name": "cloud_ice_nuclei_fraction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -90,7 +90,7 @@ class GFDLCloudMicrophysicsState:
     ua: Quantity = field(
         metadata={
             "name": "eastward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -98,7 +98,7 @@ class GFDLCloudMicrophysicsState:
     va: Quantity = field(
         metadata={
             "name": "northward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -106,7 +106,7 @@ class GFDLCloudMicrophysicsState:
     wa: Quantity = field(
         metadata={
             "name": "vertical_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -114,7 +114,7 @@ class GFDLCloudMicrophysicsState:
     pt: Quantity = field(
         metadata={
             "name": "air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "inout",
         }
@@ -122,7 +122,7 @@ class GFDLCloudMicrophysicsState:
     delp: Quantity = field(
         metadata={
             "name": "pressure_thickness_of_atmospheric_layer",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "inout",
         }
@@ -130,7 +130,7 @@ class GFDLCloudMicrophysicsState:
     delz: Quantity = field(
         metadata={
             "name": "vertical_thickness_of_atmospheric_layer",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -138,7 +138,7 @@ class GFDLCloudMicrophysicsState:
     geopotential_surface_height: Quantity = field(
         metadata={
             "name": "geopotential_surface_height",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "in",
         }
@@ -146,7 +146,7 @@ class GFDLCloudMicrophysicsState:
     preflux_water: Quantity = field(
         metadata={
             "name": "cloud_water_flux",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -154,7 +154,7 @@ class GFDLCloudMicrophysicsState:
     preflux_ice: Quantity = field(
         metadata={
             "name": "cloud_ice_flux",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -162,7 +162,7 @@ class GFDLCloudMicrophysicsState:
     preflux_rain: Quantity = field(
         metadata={
             "name": "rain_flux",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -170,7 +170,7 @@ class GFDLCloudMicrophysicsState:
     preflux_snow: Quantity = field(
         metadata={
             "name": "snow_flux",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -178,7 +178,7 @@ class GFDLCloudMicrophysicsState:
     preflux_graupel: Quantity = field(
         metadata={
             "name": "graupel_flux",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -186,7 +186,7 @@ class GFDLCloudMicrophysicsState:
     column_water: Quantity = field(
         metadata={
             "name": "cloud_water_precipitated_to_ground",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -194,7 +194,7 @@ class GFDLCloudMicrophysicsState:
     column_ice: Quantity = field(
         metadata={
             "name": "cloud_ice_precipitated_to_ground",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -202,7 +202,7 @@ class GFDLCloudMicrophysicsState:
     column_rain: Quantity = field(
         metadata={
             "name": "rain_precipitated_to_ground",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -210,7 +210,7 @@ class GFDLCloudMicrophysicsState:
     column_snow: Quantity = field(
         metadata={
             "name": "snow_precipitated_to_ground",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -218,7 +218,7 @@ class GFDLCloudMicrophysicsState:
     column_graupel: Quantity = field(
         metadata={
             "name": "graupel_precipitated_to_ground",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -226,7 +226,7 @@ class GFDLCloudMicrophysicsState:
     condensation: Quantity = field(
         metadata={
             "name": "total_column_condensation",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -234,7 +234,7 @@ class GFDLCloudMicrophysicsState:
     deposition: Quantity = field(
         metadata={
             "name": "total_column_deposition",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -242,7 +242,7 @@ class GFDLCloudMicrophysicsState:
     sublimation: Quantity = field(
         metadata={
             "name": "total_column_sublimation",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -250,7 +250,7 @@ class GFDLCloudMicrophysicsState:
     evaporation: Quantity = field(
         metadata={
             "name": "total_column_evaporation",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -258,7 +258,7 @@ class GFDLCloudMicrophysicsState:
     total_energy: Quantity = field(
         metadata={
             "name": "total_energy",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -266,7 +266,7 @@ class GFDLCloudMicrophysicsState:
     column_energy_change: Quantity = field(
         metadata={
             "name": "energy_change_in_column",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -274,7 +274,7 @@ class GFDLCloudMicrophysicsState:
     cappa: Quantity = field(
         metadata={
             "name": "cappa",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -282,7 +282,7 @@ class GFDLCloudMicrophysicsState:
     adj_vmr: Quantity = field(
         metadata={
             "name": "mixing_ratio_adjustment",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "out",
         }
@@ -290,7 +290,7 @@ class GFDLCloudMicrophysicsState:
     particle_concentration_w: Quantity = field(
         metadata={
             "name": "cloud_water_particle_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -298,7 +298,7 @@ class GFDLCloudMicrophysicsState:
     effective_diameter_w: Quantity = field(
         metadata={
             "name": "cloud_water_effective_diameter",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -306,7 +306,7 @@ class GFDLCloudMicrophysicsState:
     optical_extinction_w: Quantity = field(
         metadata={
             "name": "cloud_water_optical_extinction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -314,7 +314,7 @@ class GFDLCloudMicrophysicsState:
     radar_reflectivity_w: Quantity = field(
         metadata={
             "name": "cloud_water_radar_reflectivity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -322,7 +322,7 @@ class GFDLCloudMicrophysicsState:
     terminal_velocity_w: Quantity = field(
         metadata={
             "name": "cloud_water_terminal_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -330,7 +330,7 @@ class GFDLCloudMicrophysicsState:
     particle_concentration_r: Quantity = field(
         metadata={
             "name": "rain_particle_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -338,7 +338,7 @@ class GFDLCloudMicrophysicsState:
     effective_diameter_r: Quantity = field(
         metadata={
             "name": "rain_effective_diameter",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -346,7 +346,7 @@ class GFDLCloudMicrophysicsState:
     optical_extinction_r: Quantity = field(
         metadata={
             "name": "rain_optical_extinction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -354,7 +354,7 @@ class GFDLCloudMicrophysicsState:
     radar_reflectivity_r: Quantity = field(
         metadata={
             "name": "rain_radar_reflectivity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -362,7 +362,7 @@ class GFDLCloudMicrophysicsState:
     terminal_velocity_r: Quantity = field(
         metadata={
             "name": "rain_terminal_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -370,7 +370,7 @@ class GFDLCloudMicrophysicsState:
     particle_concentration_i: Quantity = field(
         metadata={
             "name": "cloud_ice_particle_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -378,7 +378,7 @@ class GFDLCloudMicrophysicsState:
     effective_diameter_i: Quantity = field(
         metadata={
             "name": "cloud_ice_effective_diameter",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -386,7 +386,7 @@ class GFDLCloudMicrophysicsState:
     optical_extinction_i: Quantity = field(
         metadata={
             "name": "cloud_ice_optical_extinction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -394,7 +394,7 @@ class GFDLCloudMicrophysicsState:
     radar_reflectivity_i: Quantity = field(
         metadata={
             "name": "cloud_ice_radar_reflectivity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -402,7 +402,7 @@ class GFDLCloudMicrophysicsState:
     terminal_velocity_i: Quantity = field(
         metadata={
             "name": "cloud_ice_terminal_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -410,7 +410,7 @@ class GFDLCloudMicrophysicsState:
     particle_concentration_s: Quantity = field(
         metadata={
             "name": "snow_particle_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -418,7 +418,7 @@ class GFDLCloudMicrophysicsState:
     effective_diameter_s: Quantity = field(
         metadata={
             "name": "snow_effective_diameter",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -426,7 +426,7 @@ class GFDLCloudMicrophysicsState:
     optical_extinction_s: Quantity = field(
         metadata={
             "name": "snow_optical_extinction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -434,7 +434,7 @@ class GFDLCloudMicrophysicsState:
     radar_reflectivity_s: Quantity = field(
         metadata={
             "name": "snow_radar_reflectivity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -442,7 +442,7 @@ class GFDLCloudMicrophysicsState:
     terminal_velocity_s: Quantity = field(
         metadata={
             "name": "snow_terminal_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -450,7 +450,7 @@ class GFDLCloudMicrophysicsState:
     particle_concentration_g: Quantity = field(
         metadata={
             "name": "graupel_particle_concentration",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -458,7 +458,7 @@ class GFDLCloudMicrophysicsState:
     effective_diameter_g: Quantity = field(
         metadata={
             "name": "graupel_effective_diameter",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -466,7 +466,7 @@ class GFDLCloudMicrophysicsState:
     optical_extinction_g: Quantity = field(
         metadata={
             "name": "graupel_optical_extinction",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -474,7 +474,7 @@ class GFDLCloudMicrophysicsState:
     radar_reflectivity_g: Quantity = field(
         metadata={
             "name": "graupel_radar_reflectivity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -482,7 +482,7 @@ class GFDLCloudMicrophysicsState:
     terminal_velocity_g: Quantity = field(
         metadata={
             "name": "graupel_terminal_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "unknown",
             "intent": "out",
         }

--- a/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
@@ -5,7 +5,7 @@ import ndsl.stencils.basic_operations as basic
 import pyshield.stencils.gfdl_cld_microphysics.constants as mpcons
 import pyshield.stencils.gfdl_cld_microphysics.physical_functions as physfun
 from ndsl import GridIndexing, QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 from ndsl.dsl.typing import Bool, Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
@@ -828,16 +828,16 @@ class GFDLCloudMicrophysics:
 
         # allocate memory, compile stencils, etc.
         def make_quantity(**kwargs):
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
 
         def make_quantity2d(**kwargs):
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
 
         self._tot_energy_change = make_quantity2d()
         self._bottom_density = make_quantity2d()
 
         self._adj_vmr = quantity_factory.ones(
-            dims=[X_DIM, Y_DIM, Z_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown"
         )
         self._qvapor0 = make_quantity()
         self._qliquid0 = make_quantity()
@@ -889,7 +889,7 @@ class GFDLCloudMicrophysics:
         self._rh_rain = make_quantity2d()
         self._cond = make_quantity2d()
 
-        self._gsize = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="m")
+        self._gsize = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="m")
 
         self._gsize.data[:] = np.sqrt(grid_data.area.data[:])
 

--- a/pyshield/stencils/gfdl_cld_microphysics/mp_full.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/mp_full.py
@@ -1,5 +1,5 @@
 from ndsl import GridIndexing, QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, computation, interval
 from ndsl.dsl.typing import Bool, FloatField, FloatFieldIJ
 from pyshield.stencils.gfdl_cld_microphysics._config import GFDLCloudMPConfig
@@ -87,10 +87,10 @@ class FullMicrophysics:
         self._ntimes = config.ntimes
 
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="unknown")
 
         def make_quantity_2D():
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown")
 
         self._fluxw = make_quantity()
         self._fluxr = make_quantity()

--- a/pyshield/stencils/gfdl_cld_microphysics/sedimentation.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/sedimentation.py
@@ -1,7 +1,7 @@
 import pyshield.stencils.gfdl_cld_microphysics.constants as mpcons
 import pyshield.stencils.gfdl_cld_microphysics.physical_functions as physfun
 from ndsl import GridIndexing, QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
@@ -136,7 +136,6 @@ def calc_terminal_velocity_ice(
     from __externals__ import aa, bb, cc, constant_v, dd, ee, ifflag, v_fac, v_max
 
     with computation(PARALLEL), interval(...):
-
         if constant_v:
             v_terminal = v_fac
         else:
@@ -483,10 +482,10 @@ class Sedimentation:
 
         # allocate internal storages
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="unknown")
 
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -494,12 +493,12 @@ class Sedimentation:
         for k in range(self._idx.domain[2] + 1):
             self._k_mask.data[:, :, k] = k
 
-        self._z_surface = quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+        self._z_surface = quantity_factory.zeros([I_DIM, J_DIM], units="unknown")
         self._z_edge = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            [I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown"
         )
         self._z_terminal = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            [I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown"
         )
         self._icpk = make_quantity()
         self._cvm = make_quantity()
@@ -577,7 +576,7 @@ class Sedimentation:
         if self.config.do_sedi_melt:
             self._sedi_melt_ice = stencil_factory.from_dims_halo(
                 func=sedi_melt,
-                compute_dims=[X_DIM, Y_DIM, Z_DIM],
+                compute_dims=[I_DIM, J_DIM, K_DIM],
                 externals={
                     "c1_vap": config.c1_vap,
                     "c1_liq": config.c1_liq,

--- a/pyshield/stencils/gfdl_cld_microphysics/terminal_fall.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/terminal_fall.py
@@ -4,7 +4,7 @@ import ndsl.constants as constants
 import pyshield.stencils.gfdl_cld_microphysics.constants as mpcons
 import pyshield.stencils.gfdl_cld_microphysics.physical_functions as physfun
 from ndsl import GridIndexing, QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, IntFieldIJ
 from ndsl.stencils.basic_operations import copy
@@ -379,21 +379,21 @@ class TerminalFall:
         self._idx: GridIndexing = stencil_factory.grid_indexing
 
         self._timestep = timestep
-        dims = [X_DIM, Y_DIM, Z_DIM]
+        dims = [I_DIM, J_DIM, K_DIM]
 
         # allocate internal storages
         self._q_fall = quantity_factory.zeros(dims=dims, units="unknown")
-        self._no_fall = quantity_factory.ones(dims=[X_DIM, Y_DIM], units="unknown")
+        self._no_fall = quantity_factory.ones(dims=[I_DIM, J_DIM], units="unknown")
         self._dm = quantity_factory.zeros(dims=dims, units="Pa")
-        self._tmp_energy1 = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
-        self._tmp_energy2 = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+        self._tmp_energy1 = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
+        self._tmp_energy2 = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
 
         if (self._sedflag == 3) or (self._sedflag == 4):
             self._q4_1 = quantity_factory.zeros(dims=dims, units="unknown")
             self._q4_2 = quantity_factory.zeros(dims=dims, units="unknown")
             self._q4_3 = quantity_factory.zeros(dims=dims, units="unknown")
             self._q4_4 = quantity_factory.zeros(dims=dims, units="unknown")
-            self._lev = quantity_factory.zeros([X_DIM, Y_DIM], units="", dtype=int)
+            self._lev = quantity_factory.zeros([I_DIM, J_DIM], units="", dtype=int)
 
         if self._sedflag == 4:
             self._m0 = quantity_factory.zeros(dims=dims, units="unknown")
@@ -401,8 +401,8 @@ class TerminalFall:
             # Need extra qs and precips for the sed_fac calculation
             self._q0 = quantity_factory.zeros(dims=dims, units="unknown")
             self._q1 = quantity_factory.zeros(dims=dims, units="unknown")
-            self._precip0 = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
-            self._precip1 = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+            self._precip0 = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
+            self._precip1 = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
 
         # compile stencils
 

--- a/pyshield/stencils/gfs_microphysics.py
+++ b/pyshield/stencils/gfs_microphysics.py
@@ -6,7 +6,7 @@ import numpy as np
 import ndsl.constants as constants
 import pyshield.functions.microphysics_funcs as functions
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, Int
@@ -1646,7 +1646,7 @@ class GFSMicrophysics:
         self._area = grid_data.area
 
         def make_quantity(**kwargs):
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
 
         self._rain = make_quantity()
         self._graupel = make_quantity()

--- a/pyshield/stencils/pbl/mfpblt.py
+++ b/pyshield/stencils/pbl/mfpblt.py
@@ -1,6 +1,6 @@
 import ndsl.constants as constants
 import pyshield.stencils.pbl.constants as pbl_constants
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval, sqrt
 
 # from pace.dsl.dace.orchestration import orchestrate
@@ -387,13 +387,13 @@ class PBLMassFlux:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         self._xlamuem = make_quantity()
         self._wu2 = make_quantity()

--- a/pyshield/stencils/pbl/mfscu.py
+++ b/pyshield/stencils/pbl/mfscu.py
@@ -1,6 +1,6 @@
 import ndsl.constants as constants
 import pyshield.stencils.pbl.constants as pbl_constants
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, sqrt
 
 # from pace.dsl.dace.orchestration import orchestrate
@@ -530,13 +530,13 @@ class StratocumulusMassFlux:
         # Allocate internal storages:
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         self._qtx = make_quantity()
         self._qtd = make_quantity()

--- a/pyshield/stencils/pbl/satmedmfvdiff.py
+++ b/pyshield/stencils/pbl/satmedmfvdiff.py
@@ -1,6 +1,6 @@
 import ndsl.constants as constants
 import pyshield.stencils.pbl.constants as pbl_constants
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, sqrt
 
 # from pace.dsl.dace.orchestration import orchestrate
@@ -1552,9 +1552,9 @@ class ScaleAwareTKEMoistEDMF:
             raise NotImplementedError("do_dk_hb19 has not been implemented")
 
         self._ntracers = config.ntracers
-        assert self._ntracers == 9, (
-            "PBL scheme satmedmfvdif requires ntracer " f"({config.ntracers}) == 9"
-        )
+        assert (
+            self._ntracers == 9
+        ), f"PBL scheme satmedmfvdif requires ntracer ({config.ntracers}) == 9"
 
         self._ntrac1 = self._ntracers - 1
 
@@ -1570,13 +1570,13 @@ class ScaleAwareTKEMoistEDMF:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate internal variables:
         km1 = idx.domain[2] - 1
@@ -1598,7 +1598,7 @@ class ScaleAwareTKEMoistEDMF:
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1710,14 +1710,14 @@ class ScaleAwareTKEMoistEDMF:
         self._xmfd = make_quantity()
 
         self._mlenflg = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Bool,
         )
         self._pblflg = make_quantity_2D(Bool)
         self._sfcflg = make_quantity_2D(Bool)
         self._flg = make_quantity_2D(Bool)
-        self._scuflg = quantity_factory.ones([X_DIM, Y_DIM], units="none", dtype=Bool)
+        self._scuflg = quantity_factory.ones([I_DIM, J_DIM], units="none", dtype=Bool)
         self._pcnvflg = make_quantity_2D(Bool)
 
         # Limiting pressures for vertical loops:
@@ -1730,24 +1730,24 @@ class ScaleAwareTKEMoistEDMF:
 
         # Allocate higher order fields
         self._f2 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._a2 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._qcko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._qcdo = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )

--- a/pyshield/stencils/pbl/satmedmfvdiff_state.py
+++ b/pyshield/stencils/pbl/satmedmfvdiff_state.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.typing import Float, Int
 from pyshield._config import TRACER_DIM
 
@@ -15,7 +15,7 @@ class SATMEDMFVDiffState:
     u1: Quantity = field(
         metadata={
             "name": "eastward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -23,7 +23,7 @@ class SATMEDMFVDiffState:
     v1: Quantity = field(
         metadata={
             "name": "northward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -31,7 +31,7 @@ class SATMEDMFVDiffState:
     t1: Quantity = field(
         metadata={
             "name": "air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "in",
         }
@@ -39,7 +39,7 @@ class SATMEDMFVDiffState:
     q1: Quantity = field(
         metadata={
             "name": "tracer_quantities",
-            "dims": [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM, TRACER_DIM],
             "units": "",
             "intent": "in",
         }
@@ -47,7 +47,7 @@ class SATMEDMFVDiffState:
     du: Quantity = field(
         metadata={
             "name": "eastward_wind_tendency",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s**2",
             "intent": "inout",
         }
@@ -55,7 +55,7 @@ class SATMEDMFVDiffState:
     dv: Quantity = field(
         metadata={
             "name": "northward_wind_tendency",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s**2",
             "intent": "inout",
         }
@@ -63,7 +63,7 @@ class SATMEDMFVDiffState:
     dtdt: Quantity = field(
         metadata={
             "name": "air_temperature_tendency",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK/s",
             "intent": "inout",
         }
@@ -71,7 +71,7 @@ class SATMEDMFVDiffState:
     rtg: Quantity = field(
         metadata={
             "name": "tracer_tendency",
-            "dims": [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM, TRACER_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -79,7 +79,7 @@ class SATMEDMFVDiffState:
     prsl: Quantity = field(
         metadata={
             "name": "mean_layer_pressure",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -87,7 +87,7 @@ class SATMEDMFVDiffState:
     phii: Quantity = field(
         metadata={
             "name": "interface_geopotential_height",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "m",
             "intent": "in",
         }
@@ -95,7 +95,7 @@ class SATMEDMFVDiffState:
     phil: Quantity = field(
         metadata={
             "name": "layer_geopotential_height",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m",
             "intent": "in",
         }
@@ -103,7 +103,7 @@ class SATMEDMFVDiffState:
     prsi: Quantity = field(
         metadata={
             "name": "interface_pressure",
-            "dims": [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            "dims": [I_DIM, J_DIM, K_INTERFACE_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -111,7 +111,7 @@ class SATMEDMFVDiffState:
     prslk: Quantity = field(
         metadata={
             "name": "Exner_function",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -119,7 +119,7 @@ class SATMEDMFVDiffState:
     hsw: Quantity = field(
         metadata={
             "name": "shortwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "k/s",
             "intent": "in",
         }
@@ -127,7 +127,7 @@ class SATMEDMFVDiffState:
     hlw: Quantity = field(
         metadata={
             "name": "longwave_heating_rate",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "k/s",
             "intent": "in",
         }
@@ -135,7 +135,7 @@ class SATMEDMFVDiffState:
     islimsk: Quantity = field(
         metadata={
             "name": "sea_land_ice_mask",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "in",
             "dtype": Int,
@@ -144,7 +144,7 @@ class SATMEDMFVDiffState:
     kpbl: Quantity = field(
         metadata={
             "name": "pbl_index",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "inout",
             "dtype": Int,
@@ -153,7 +153,7 @@ class SATMEDMFVDiffState:
     kinver: Quantity = field(
         metadata={
             "name": "inversion_layer_index",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "-",
             "intent": "in",
             "dtype": Int,
@@ -162,7 +162,7 @@ class SATMEDMFVDiffState:
     hpbl: Quantity = field(
         metadata={
             "name": "pbl_height",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "inout",
         }
@@ -170,7 +170,7 @@ class SATMEDMFVDiffState:
     xmu: Quantity = field(
         metadata={
             "name": "zenith_angle_adjust_factor",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -178,7 +178,7 @@ class SATMEDMFVDiffState:
     psk: Quantity = field(
         metadata={
             "name": "log_surface_pressure",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -186,7 +186,7 @@ class SATMEDMFVDiffState:
     rbsoil: Quantity = field(
         metadata={
             "name": "bulk_Richardson_number",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -194,7 +194,7 @@ class SATMEDMFVDiffState:
     zorl: Quantity = field(
         metadata={
             "name": "composite_surface_roughness",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "cm",
             "intent": "in",
         }
@@ -202,7 +202,7 @@ class SATMEDMFVDiffState:
     tsea: Quantity = field(
         metadata={
             "name": "surface_temperature",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "degK",
             "intent": "in",
         }
@@ -210,7 +210,7 @@ class SATMEDMFVDiffState:
     u10m: Quantity = field(
         metadata={
             "name": "10_m_eastward_wind",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -218,7 +218,7 @@ class SATMEDMFVDiffState:
     v10m: Quantity = field(
         metadata={
             "name": "10_m_northward_wind",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -226,7 +226,7 @@ class SATMEDMFVDiffState:
     fm: Quantity = field(
         metadata={
             "name": "fm_PBL_parameter",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -234,7 +234,7 @@ class SATMEDMFVDiffState:
     fh: Quantity = field(
         metadata={
             "name": "fh_PBL_parameter",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -242,7 +242,7 @@ class SATMEDMFVDiffState:
     evap: Quantity = field(
         metadata={
             "name": "evaporation_from_latent_heat_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -250,7 +250,7 @@ class SATMEDMFVDiffState:
     heat: Quantity = field(
         metadata={
             "name": "surface_heat_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "in",
         }
@@ -258,7 +258,7 @@ class SATMEDMFVDiffState:
     stress: Quantity = field(
         metadata={
             "name": "surface_wind_stress",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -266,7 +266,7 @@ class SATMEDMFVDiffState:
     spd1: Quantity = field(
         metadata={
             "name": "surface_wind_speed",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -274,7 +274,7 @@ class SATMEDMFVDiffState:
     delta: Quantity = field(
         metadata={
             "name": "atmospheric_pressure_thickness",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -282,7 +282,7 @@ class SATMEDMFVDiffState:
     dusfc: Quantity = field(
         metadata={
             "name": "surface_eastward_wind_tendency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s**2",
             "intent": "inout",
         }
@@ -290,7 +290,7 @@ class SATMEDMFVDiffState:
     dvsfc: Quantity = field(
         metadata={
             "name": "surface_northward_wind_tendency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s**2",
             "intent": "inout",
         }
@@ -298,7 +298,7 @@ class SATMEDMFVDiffState:
     dtsfc: Quantity = field(
         metadata={
             "name": "surface_air_temperature_tendency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "degK/s",
             "intent": "inout",
         }
@@ -306,7 +306,7 @@ class SATMEDMFVDiffState:
     dqsfc: Quantity = field(
         metadata={
             "name": "surface_humidity_tendency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "km/km*s",
             "intent": "inout",
         }
@@ -314,7 +314,7 @@ class SATMEDMFVDiffState:
     dkt: Quantity = field(
         metadata={
             "name": "",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "out",
         }

--- a/pyshield/stencils/physics.py
+++ b/pyshield/stencils/physics.py
@@ -5,7 +5,7 @@ import numpy as np
 import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, cos, exp
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval, log, sin
@@ -1146,10 +1146,10 @@ class Physics:
         self._hydro_delp = namelist.hydro_delp
 
         self._level_flip = self.quantity_factory.zeros(
-            dims=[Z_INTERFACE_DIM], units="", dtype=Int
+            dims=[K_INTERFACE_DIM], units="", dtype=Int
         )
         self._layer_flip = self.quantity_factory.zeros(
-            dims=[Z_INTERFACE_DIM], units="", dtype=Int
+            dims=[K_INTERFACE_DIM], units="", dtype=Int
         )
         for k in range(npz):
             self._level_flip.data[k] = npz - 1 - 2 * k
@@ -1158,13 +1158,13 @@ class Physics:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                dims=[X_DIM, Y_DIM, Z_DIM], units="unknown"
+                dims=[I_DIM, J_DIM, K_DIM], units="unknown"
             )
 
         def make_quantity_2d():
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
 
-        self._rain1 = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+        self._rain1 = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
         self._dm3d = make_quantity()
         self._del_gz = make_quantity()
         self._u1 = make_quantity()
@@ -1174,10 +1174,10 @@ class Physics:
         self._prsl1 = make_quantity()
         self._delp1 = make_quantity()
         self._prsi1 = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown"
         )
         self._prsik1 = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown"
         )
         self._prslk1 = make_quantity()
         self._qvapor1 = make_quantity()
@@ -1191,7 +1191,7 @@ class Physics:
         self._qcld1 = make_quantity()
         self._phil1 = make_quantity()
         self._phii1 = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_INTERFACE_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown"
         )
         # TODO: once surface state is a required argument we don't need these copies
         self._sfcwind = make_quantity_2d()
@@ -1201,7 +1201,7 @@ class Physics:
         self._f10m = make_quantity_2d()
         self._emis = make_quantity_2d()
         self._srflg = self.quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM], units="unknown", dtype=Bool
+            dims=[I_DIM, J_DIM], units="unknown", dtype=Bool
         )
         self._hice = make_quantity_2d()
         self._fice = make_quantity_2d()
@@ -1381,12 +1381,12 @@ class Physics:
         self._dtdt = make_quantity()
         self._dtdtc = make_quantity()
         self._dqdt = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._qgrs = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )

--- a/pyshield/stencils/shallow_convection/samf_shalconv_state.py
+++ b/pyshield/stencils/shallow_convection/samf_shalconv_state.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Float, Int
 from pyshield.stencils.shallow_convection._config import SC_TRACER_DIM
 
@@ -15,7 +15,7 @@ class SAMFShalConvState:
     q1: Quantity = field(
         metadata={
             "name": "specific_humidity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -23,7 +23,7 @@ class SAMFShalConvState:
     t1: Quantity = field(
         metadata={
             "name": "air_temperature",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "degK",
             "intent": "inout",
         }
@@ -31,7 +31,7 @@ class SAMFShalConvState:
     u1: Quantity = field(
         metadata={
             "name": "eastward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -39,7 +39,7 @@ class SAMFShalConvState:
     v1: Quantity = field(
         metadata={
             "name": "northward_wind",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m/s",
             "intent": "inout",
         }
@@ -47,7 +47,7 @@ class SAMFShalConvState:
     qtr: Quantity = field(
         metadata={
             "name": "convected_tracers",
-            "dims": [X_DIM, Y_DIM, Z_DIM, SC_TRACER_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM, SC_TRACER_DIM],
             "units": "kg/kg",
             "intent": "in",
         }
@@ -56,7 +56,7 @@ class SAMFShalConvState:
     dot: Quantity = field(
         metadata={
             "name": "layer_mean_vertical_velocity",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa/s",
             "intent": "in",
         }
@@ -64,7 +64,7 @@ class SAMFShalConvState:
     hpbl: Quantity = field(
         metadata={
             "name": "pbl_height",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "in",
         }
@@ -72,7 +72,7 @@ class SAMFShalConvState:
     prslp: Quantity = field(
         metadata={
             "name": "mean_layer_pressure",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -80,7 +80,7 @@ class SAMFShalConvState:
     phil: Quantity = field(
         metadata={
             "name": "layer_geopotential",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "m**2/s**2",
             "intent": "in",
         }
@@ -88,7 +88,7 @@ class SAMFShalConvState:
     delp: Quantity = field(
         metadata={
             "name": "pressure_thickness_of_atmospheric_layer",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -96,7 +96,7 @@ class SAMFShalConvState:
     cnvw: Quantity = field(
         metadata={
             "name": "convective_cloud_water",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/kg",
             "intent": "out",
         }
@@ -104,7 +104,7 @@ class SAMFShalConvState:
     cnvc: Quantity = field(
         metadata={
             "name": "convective_cloud_cover",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "",
             "intent": "out",
         }
@@ -112,7 +112,7 @@ class SAMFShalConvState:
     ud_mf: Quantity = field(
         metadata={
             "name": "updraft_mass_flux_times_timestep",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/m**2",
             "intent": "out",
         }
@@ -120,7 +120,7 @@ class SAMFShalConvState:
     dt_mf: Quantity = field(
         metadata={
             "name": "ud_mf_at_cloud_top",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "kg/m**2",
             "intent": "out",
         }
@@ -128,7 +128,7 @@ class SAMFShalConvState:
     psp: Quantity = field(
         metadata={
             "name": "surface_pressure",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -136,7 +136,7 @@ class SAMFShalConvState:
     rn: Quantity = field(
         metadata={
             "name": "convective_rain",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "out",
         }
@@ -144,7 +144,7 @@ class SAMFShalConvState:
     kcnv: Quantity = field(
         metadata={
             "name": "flag_for_deep_convection",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
             "dtype": Int,
@@ -153,7 +153,7 @@ class SAMFShalConvState:
     kbot: Quantity = field(
         metadata={
             "name": "index_for_cloud_base",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "out",
             "dtype": Int,
@@ -162,7 +162,7 @@ class SAMFShalConvState:
     ktop: Quantity = field(
         metadata={
             "name": "index_for_cloud_top",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "out",
             "dtype": Int,
@@ -171,7 +171,7 @@ class SAMFShalConvState:
     garea: Quantity = field(
         metadata={
             "name": "grid_area",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m**2",
             "intent": "in",
         }
@@ -180,7 +180,7 @@ class SAMFShalConvState:
     islimsk: Quantity = field(
         metadata={
             "name": "land_mask",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
             "dtype": Int,

--- a/pyshield/stencils/shallow_convection/samfshalconv.py
+++ b/pyshield/stencils/shallow_convection/samfshalconv.py
@@ -16,7 +16,7 @@ import pyshield.stencils.shallow_convection.constants as sccons
 
 # from pace.dsl.dace.orchestration import orchestrate
 from ndsl import QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import (
     Bool,
     BoolFieldIJ,
@@ -245,7 +245,6 @@ def init_final(
         tem = 0.0
 
         if cnvflg and k_mask <= kmax:
-
             # Convert prsl from centibar to millibar, set normalized mass
             # flux to 1, cloud properties to 0, and save model state
             # variables (after advection/turbulence)
@@ -814,7 +813,6 @@ def stencil_static9(
         tem = 0.0
 
         if cnvflg:
-
             # Use pfld_kbcon and pfld_kbcon1 to represent
             # tem = pfld(i,kbcon(i)) - pfld(i,kbcon1(i))
             tem = pfld_kbcon - pfld_kbcon1
@@ -1486,7 +1484,6 @@ def comp_tendencies(
 
         # Changes due to subsidence and entrainment
         if cnvflg and k_mask > kb and k_mask < ktcon:
-
             dp = 1000.0 * del0
             dz = zi[0, 0, 0] - zi[0, 0, -1]
             gdp = constants.GRAV / dp
@@ -1666,7 +1663,6 @@ def comp_tendencies_tr(
             dellae[0, 0, 0][n_tracer] = 0.0
 
     with computation(PARALLEL), interval(1, -1):
-
         tem1 = 0.0
         tem2 = 0.0
         dp = 0.0
@@ -1683,7 +1679,6 @@ def comp_tendencies_tr(
             )
 
     with computation(PARALLEL), interval(1, None):
-
         # Cloud top
         if cnvflg and ktcon == k_mask:
             dp = 1000.0 * del0
@@ -1749,7 +1744,6 @@ def feedback_control_update_mass_flux(
     from __externals__ import dt2
 
     with computation(FORWARD), interval(0, 1):
-
         # Initialize flg
         flg = cnvflg
         rntot = 0.0
@@ -1822,14 +1816,12 @@ def feedback_control_update_mass_flux(
     # evaporation of convective precipitation
     with computation(BACKWARD):
         with interval(...):
-
             evef = 0.0
             dp = 0.0
             tem = 0.0
             tem1 = 0.0
 
             if k_mask <= kmax:
-
                 deltv = 0.0
                 delq = 0.0
                 qevap = 0.0
@@ -1971,7 +1963,6 @@ def store_aero_conc(
     k_aerosol: Int,
 ):
     with computation(PARALLEL), interval(...):
-
         # Store aerosol concentrations if present
         if cnvflg and rn > 0.0 and k_mask <= kmax:
             qtr[0, 0, 0][n_tracer] = qaero[0, 0, 0][k_aerosol]
@@ -1998,7 +1989,6 @@ def separate_detrained_cw(
         tem1 = 0.0
 
         if cnvflg and k_mask >= kbcon and k_mask <= ktcon:
-
             tem = dellal * xmb * dt2
             tem1 = (sccons.SHAL_TCR - t1) * sccons.SHAL_TCRF
             tem1 = min(1.0, tem1)
@@ -2027,7 +2017,6 @@ def tke_contribution(
     from __externals__ import ntk
 
     with computation(FORWARD), interval(1, -1):
-
         tem = 0.0
         tem1 = 0.0
         ptem = 0.0
@@ -2195,19 +2184,19 @@ class ScaleAwareMassFluxShallowConvection:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type=Float):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate arrays
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -2305,31 +2294,31 @@ class ScaleAwareMassFluxShallowConvection:
         self._prsl_ktcon = make_quantity_2D()
 
         self._ctr = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ctro = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ecko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._dellae = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._delebar = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -2337,12 +2326,12 @@ class ScaleAwareMassFluxShallowConvection:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_par_and_arr = stencil_factory.from_dims_halo(
             func=init_par_and_arr,
@@ -2350,32 +2339,32 @@ class ScaleAwareMassFluxShallowConvection:
                 "asolfac": self._asolfac,
                 "c0s": self._c0s,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_kbm_kmax = stencil_factory.from_dims_halo(
             func=init_kbm_kmax,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_final = stencil_factory.from_dims_halo(
             func=init_final,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_tracers = stencil_factory.from_dims_halo(
             func=init_tracers,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static0 = stencil_factory.from_dims_halo(
             func=stencil_static0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static1 = stencil_factory.from_dims_halo(
             func=stencil_static1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static2 = stencil_factory.from_dims_halo(
             func=stencil_static2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static3 = stencil_factory.from_dims_halo(
             func=stencil_static3,
@@ -2383,40 +2372,40 @@ class ScaleAwareMassFluxShallowConvection:
                 "ntk": self._ntk,
                 "clam": self._clam,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic0 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static5 = stencil_factory.from_dims_halo(
             func=stencil_static5,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic1 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static7 = stencil_factory.from_dims_halo(
             func=stencil_static7,
             externals={"pgcon": self._pgcon},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic2 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_update_kbcon1_cnvflg = stencil_factory.from_dims_halo(
             func=stencil_update_kbcon1_cnvflg,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static9 = stencil_factory.from_dims_halo(
             func=stencil_static9,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static10 = stencil_factory.from_dims_halo(
             func=stencil_static10,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static11 = stencil_factory.from_dims_halo(
             func=stencil_static11,
@@ -2428,40 +2417,40 @@ class ScaleAwareMassFluxShallowConvection:
                 "ncloud": self._ncloud,
                 "top_shal": self._top_shal,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static12 = stencil_factory.from_dims_halo(
             func=stencil_static12,
             externals={"c1": self._c1, "ncloud": self._ncloud},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         if self._ncloud > 0:
             self._stencil_static13 = stencil_factory.from_dims_halo(
                 func=stencil_static13,
-                compute_dims=[X_DIM, Y_DIM, Z_DIM],
+                compute_dims=[I_DIM, J_DIM, K_DIM],
             )
         self._stencil_static14 = stencil_factory.from_dims_halo(
             func=stencil_static14,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._comp_tendencies = stencil_factory.from_dims_halo(
             func=comp_tendencies,
             externals={"dt2": self._dt2},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._comp_tendencies_tr = stencil_factory.from_dims_halo(
             func=comp_tendencies_tr,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._feedback_control_update_mass_flux = stencil_factory.from_dims_halo(
             func=feedback_control_update_mass_flux,
             externals={"dt2": self._dt2},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._feedback_control_upd_trr = stencil_factory.from_dims_halo(
             func=feedback_control_upd_trr,
             externals={"dt2": self._dt2},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         if self._ncloud > 0:
             self._separate_detrained_cw = stencil_factory.from_dims_halo(
@@ -2471,7 +2460,7 @@ class ScaleAwareMassFluxShallowConvection:
                     "ntiw": self._ntiw,
                     "ntcw": self._ntcw,
                 },
-                compute_dims=[X_DIM, Y_DIM, Z_DIM],
+                compute_dims=[I_DIM, J_DIM, K_DIM],
             )
         if self._ntk > 0:
             self._tke_contribution = stencil_factory.from_dims_halo(
@@ -2479,12 +2468,12 @@ class ScaleAwareMassFluxShallowConvection:
                 externals={
                     "ntk": self._ntk,
                 },
-                compute_dims=[X_DIM, Y_DIM, Z_DIM],
+                compute_dims=[I_DIM, J_DIM, K_DIM],
             )
         # if self._do_aerosols:
         #     self._store_aero_conc = stencil_factory.from_dims_halo(
         #         func=store_aero_conc,
-        #         compute_dims=[X_DIM, Y_DIM, Z_DIM],
+        #         compute_dims=[I_DIM, J_DIM, K_DIM],
         #     )
 
     def __call__(

--- a/pyshield/stencils/surface/sfc_state.py
+++ b/pyshield/stencils/surface/sfc_state.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Bool, Float, Int
 
 
@@ -14,7 +14,7 @@ class SurfaceState:
     tsfc: Quantity = field(
         metadata={
             "name": "surface_temperature",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "K",
             "intent": "inout",
         }
@@ -23,7 +23,7 @@ class SurfaceState:
     stc: Quantity = field(
         metadata={
             "name": "soil_temperature_content",
-            "dims": [X_DIM, Y_DIM, Z_DIM],
+            "dims": [I_DIM, J_DIM, K_DIM],
             "units": "K",
             "intent": "inout",
         }
@@ -32,7 +32,7 @@ class SurfaceState:
     qsfc: Quantity = field(
         metadata={
             "name": "surface_specific_humidity",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "kg/kg",
             "intent": "inout",
         }
@@ -41,7 +41,7 @@ class SurfaceState:
     snowd: Quantity = field(
         metadata={
             "name": "snow_depth",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "mm",
             "intent": "inout",
         }
@@ -50,7 +50,7 @@ class SurfaceState:
     sncovr: Quantity = field(
         metadata={
             "name": "snow_cover_area_fraction",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -59,7 +59,7 @@ class SurfaceState:
     snoalb: Quantity = field(
         metadata={
             "name": "maximum_snow_albedo_in_fraction",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -68,7 +68,7 @@ class SurfaceState:
     albedo: Quantity = field(
         metadata={
             "name": "mean_albedo",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -77,7 +77,7 @@ class SurfaceState:
     alvsf: Quantity = field(
         metadata={
             "name": "mean_visible_albedo_with_strong_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -85,7 +85,7 @@ class SurfaceState:
     alnsf: Quantity = field(
         metadata={
             "name": "mean_near_ir_albedo_with_strong_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -93,7 +93,7 @@ class SurfaceState:
     alvwf: Quantity = field(
         metadata={
             "name": "mean_visible_albedo_with_weak_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -101,7 +101,7 @@ class SurfaceState:
     alnwf: Quantity = field(
         metadata={
             "name": "mean_near_ir_albedo_with_weak_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -110,7 +110,7 @@ class SurfaceState:
     zorl: Quantity = field(
         metadata={
             "name": "composite_surface_roughness",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "cm",
             "intent": "in",
         }
@@ -119,7 +119,7 @@ class SurfaceState:
     ztrl: Quantity = field(
         metadata={
             "name": "t_and_q_surface_roughness",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "cm",
             "intent": "in",
         }
@@ -128,7 +128,7 @@ class SurfaceState:
     hprim: Quantity = field(
         metadata={
             "name": "",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -137,7 +137,7 @@ class SurfaceState:
     wind: Quantity = field(
         metadata={
             "name": "surface_wind_speed",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "out",
         }
@@ -146,7 +146,7 @@ class SurfaceState:
     uustar: Quantity = field(
         metadata={
             "name": "boundary_layer_param",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "out",
         }
@@ -155,7 +155,7 @@ class SurfaceState:
     islmsk: Quantity = field(
         metadata={
             "name": "ice_sea_land_mask",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
             "type": Int,
@@ -165,7 +165,7 @@ class SurfaceState:
     vegtype: Quantity = field(
         metadata={
             "name": "vegetation_type",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
             "type": Int,
@@ -175,7 +175,7 @@ class SurfaceState:
     vfrac: Quantity = field(
         metadata={
             "name": "vegetation_fraction",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -184,7 +184,7 @@ class SurfaceState:
     shdmax: Quantity = field(
         metadata={
             "name": "max_fractional_green_vegetation_cover",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -193,7 +193,7 @@ class SurfaceState:
     ffmm: Quantity = field(
         metadata={
             "name": "fm_PBL_parameter",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -202,7 +202,7 @@ class SurfaceState:
     ffhh: Quantity = field(
         metadata={
             "name": "fh_PBL_parameter",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -211,7 +211,7 @@ class SurfaceState:
     f10m: Quantity = field(
         metadata={
             "name": "sigma1_10m_wind_ratio",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -220,7 +220,7 @@ class SurfaceState:
     sfcemis: Quantity = field(
         metadata={
             "name": "sfc_lw_emissivity_fraction",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -229,7 +229,7 @@ class SurfaceState:
     srflag: Quantity = field(
         metadata={
             "name": "rain_snow_precipitation_flag",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
             "type": Bool,
@@ -239,7 +239,7 @@ class SurfaceState:
     facsf: Quantity = field(
         metadata={
             "name": "fractional_coverage_with_strong_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -248,7 +248,7 @@ class SurfaceState:
     facwf: Quantity = field(
         metadata={
             "name": "fractional_coverage_with_weak_cosz_dependency",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -257,7 +257,7 @@ class SurfaceState:
     hice: Quantity = field(
         metadata={
             "name": "sea_ice_thickness",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "inout",
         }
@@ -266,7 +266,7 @@ class SurfaceState:
     fice: Quantity = field(
         metadata={
             "name": "ice_fraction_over_open_water_grid",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "inout",
         }
@@ -275,7 +275,7 @@ class SurfaceState:
     tisfc: Quantity = field(
         metadata={
             "name": "surface_temperature_over_ice_fraction",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "K",
             "intent": "inout",
         }
@@ -284,7 +284,7 @@ class SurfaceState:
     weasd: Quantity = field(
         metadata={
             "name": "water_equiv_accumulated_snow_depth",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "kg/m**2",
             "intent": "inout",
         }
@@ -293,7 +293,7 @@ class SurfaceState:
     tprcp: Quantity = field(
         metadata={
             "name": "total_precip",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "unknown",
             "intent": "out",
         }
@@ -302,7 +302,7 @@ class SurfaceState:
     u1: Quantity = field(
         metadata={
             "name": "lowest_level_x_wind",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -311,7 +311,7 @@ class SurfaceState:
     v1: Quantity = field(
         metadata={
             "name": "lowest_level_y_wind",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m/s",
             "intent": "in",
         }
@@ -320,7 +320,7 @@ class SurfaceState:
     qvapor: Quantity = field(
         metadata={
             "name": "lowest_level_specific_humidity",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "kg/kg",
             "intent": "in",
         }
@@ -329,7 +329,7 @@ class SurfaceState:
     t1: Quantity = field(
         metadata={
             "name": "lowest_level_temperature",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "K",
             "intent": "in",
         }
@@ -338,7 +338,7 @@ class SurfaceState:
     ps: Quantity = field(
         metadata={
             "name": "surface_pressure",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -347,7 +347,7 @@ class SurfaceState:
     phil: Quantity = field(
         metadata={
             "name": "layer_geopotential_height",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "m",
             "intent": "in",
         }
@@ -356,7 +356,7 @@ class SurfaceState:
     prsl1: Quantity = field(
         metadata={
             "name": "",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -365,7 +365,7 @@ class SurfaceState:
     prsik: Quantity = field(
         metadata={
             "name": "surface_layer_mean_pressure",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "in",
         }
@@ -374,7 +374,7 @@ class SurfaceState:
     prslk: Quantity = field(
         metadata={
             "name": "Exner_function",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "in",
         }
@@ -383,7 +383,7 @@ class SurfaceState:
     rb: Quantity = field(
         metadata={
             "name": "bulk_Richardson_number",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "out",
         }
@@ -392,7 +392,7 @@ class SurfaceState:
     stress: Quantity = field(
         metadata={
             "name": "surface_wind_stress",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "Pa",
             "intent": "out",
         }
@@ -401,7 +401,7 @@ class SurfaceState:
     hflx: Quantity = field(
         metadata={
             "name": "sensible_heat_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "out",
         }
@@ -410,7 +410,7 @@ class SurfaceState:
     evap: Quantity = field(
         metadata={
             "name": "evaporation_from_latent_heat_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "",
             "intent": "out",
         }
@@ -419,7 +419,7 @@ class SurfaceState:
     sfcdlw: Quantity = field(
         metadata={
             "name": "downward_longwave_surface_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "in",
         }
@@ -428,7 +428,7 @@ class SurfaceState:
     sfcdsw: Quantity = field(
         metadata={
             "name": "downward_shortwave_surface_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "in",
         }
@@ -437,7 +437,7 @@ class SurfaceState:
     sfcnsw: Quantity = field(
         metadata={
             "name": "net_shortwave_surface_flux",
-            "dims": [X_DIM, Y_DIM],
+            "dims": [I_DIM, J_DIM],
             "units": "W/m**2",
             "intent": "in",
         }

--- a/pyshield/stencils/surface/surface_layer.py
+++ b/pyshield/stencils/surface/surface_layer.py
@@ -2,7 +2,7 @@ import ndsl.constants as constants
 
 # from pace.dsl.dace.orchestration import orchestrate
 from ndsl import Quantity, QuantityFactory, StencilFactory
-from ndsl.constants import X_DIM, Y_DIM
+from ndsl.constants import I_DIM, J_DIM
 from ndsl.dsl.gt4py import FORWARD, computation, interval
 from ndsl.dsl.typing import (
     Bool,
@@ -157,7 +157,7 @@ class SurfaceLayer:
 
         def make_quantity_2d() -> Quantity:
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=Float,
             )
@@ -193,13 +193,13 @@ class SurfaceLayer:
         self._prsl1 = make_quantity_2d()
 
         self._flag_guess = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="None",
             dtype=Bool,
         )
 
         self._flag_iter = quantity_factory.ones(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="None",
             dtype=Bool,
         )

--- a/pyshield/update/fv_update_phys.py
+++ b/pyshield/update/fv_update_phys.py
@@ -7,7 +7,7 @@ from ndsl import (
     WrappedHaloUpdater,
     orchestrate,
 )
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, exp
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval, log
@@ -134,7 +134,7 @@ class ApplyPhysicsToDycore:
         origin = grid_indexing.origin_compute()
         shape = grid_indexing.max_shape
         full_3Dfield_1pts_halo_spec = quantity_factory.get_quantity_halo_spec(
-            dims=[X_DIM, Y_DIM, Z_DIM],
+            dims=[I_DIM, J_DIM, K_DIM],
             n_halo=1,
         )
         self._udt_halo_updater = WrappedHaloUpdater(
@@ -148,8 +148,8 @@ class ApplyPhysicsToDycore:
             ["v_dt"],
         )
         # TODO: check if we actually need surface winds
-        self._u_srf = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="m/s")
-        self._v_srf = quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="m/s")
+        self._u_srf = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="m/s")
+        self._v_srf = quantity_factory.zeros(dims=[I_DIM, J_DIM], units="m/s")
 
     def __call__(
         self,

--- a/pyshield/update/update_atmos_state.py
+++ b/pyshield/update/update_atmos_state.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pyfv3
 from ndsl import QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_INTERFACE_DIM
+from ndsl.constants import J_INTERFACE_DIM, K_INTERFACE_DIM, X_INTERFACE_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DriverGridData, GridData
@@ -160,8 +160,8 @@ class DycoreToPhysics:
             copy_dycore_to_physics,
             compute_dims=[
                 X_INTERFACE_DIM,
-                Y_INTERFACE_DIM,
-                Z_INTERFACE_DIM,
+                J_INTERFACE_DIM,
+                K_INTERFACE_DIM,
             ],
             compute_halos=(0, 0),
         )

--- a/pyshield/update/update_atmos_state.py
+++ b/pyshield/update/update_atmos_state.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pyfv3
 from ndsl import QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import J_INTERFACE_DIM, K_INTERFACE_DIM, X_INTERFACE_DIM
+from ndsl.constants import J_INTERFACE_DIM, K_INTERFACE_DIM, I_INTERFACE_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DriverGridData, GridData
@@ -159,7 +159,7 @@ class DycoreToPhysics:
         self._copy_dycore_to_physics = stencil_factory.from_dims_halo(
             copy_dycore_to_physics,
             compute_dims=[
-                X_INTERFACE_DIM,
+                I_INTERFACE_DIM,
                 J_INTERFACE_DIM,
                 K_INTERFACE_DIM,
             ],

--- a/pyshield/update/update_atmos_state.py
+++ b/pyshield/update/update_atmos_state.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pyfv3
 from ndsl import QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import J_INTERFACE_DIM, K_INTERFACE_DIM, I_INTERFACE_DIM
+from ndsl.constants import I_INTERFACE_DIM, J_INTERFACE_DIM, K_INTERFACE_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DriverGridData, GridData

--- a/pyshield/update/update_dwind_phys.py
+++ b/pyshield/update/update_dwind_phys.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, StencilFactory, TilePartitioner, orchestrate
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldI, FloatFieldIJ
 from ndsl.grid import DriverGridData
@@ -199,7 +199,7 @@ class AGrid2DGridPhysics:
         self.east_edge = grid_indexing.east_edge
 
         def make_quantity():
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
 
         if self._grid_type <= 3:
             self._ue_1 = make_quantity()

--- a/tests/integration/test_all.py
+++ b/tests/integration/test_all.py
@@ -9,6 +9,7 @@ import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import NullComm, Quantity, QuantityFactory, StencilFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -32,7 +33,7 @@ def setup_infrastructure(
     nzsoil: int,
     nhalo: int,
     etafile: Path,
-    backend: str = "numpy",
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend
@@ -145,8 +146,8 @@ def states_from_fortran_restarts(
 
 # TODO: parameterize over schemes
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_pyshield_runs(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_pyshield_runs(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/integration/test_gfdl_cld_mp.py
+++ b/tests/integration/test_gfdl_cld_mp.py
@@ -8,6 +8,7 @@ import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import NullComm, Quantity, QuantityFactory, StencilFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -21,7 +22,12 @@ from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, nhalo: int, etafile: Path, backend: str = "numpy"
+    nx: int,
+    ny: int,
+    nz: int,
+    nhalo: int,
+    etafile: Path,
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend
@@ -105,8 +111,8 @@ def states_from_fortran_restarts(
 
 
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_pyshield_runswith_gfdl_cld_mp(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_pyshield_runswith_gfdl_cld_mp(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/integration/test_gfs_mp.py
+++ b/tests/integration/test_gfs_mp.py
@@ -8,6 +8,7 @@ import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import NullComm, Quantity, QuantityFactory, StencilFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -20,7 +21,12 @@ from pyshield import PHYSICS_PACKAGES, Physics, PhysicsConfig, PhysicsState
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, nhalo: int, etafile: Path, backend: str = "numpy"
+    nx: int,
+    ny: int,
+    nz: int,
+    nhalo: int,
+    etafile: Path,
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend
@@ -104,8 +110,8 @@ def states_from_fortran_restarts(
 
 
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_pyshield_runswith_gfs_mp(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_pyshield_runswith_gfs_mp(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/integration/test_radiation_driver.py
+++ b/tests/integration/test_radiation_driver.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 from ndsl import NullComm, Quantity, QuantityFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -23,7 +24,12 @@ from pyshield.stencils.surface import SurfaceState
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, nhalo: int, etafile: Path, backend: str = "numpy"
+    nx: int,
+    ny: int,
+    nz: int,
+    nhalo: int,
+    etafile: Path,
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend

--- a/tests/integration/test_samfshalconv.py
+++ b/tests/integration/test_samfshalconv.py
@@ -8,6 +8,7 @@ import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import NullComm, Quantity, QuantityFactory, StencilFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -21,7 +22,12 @@ from pyshield.stencils.shallow_convection import ShallowConvectionConfig
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, nhalo: int, etafile: Path, backend: str = "numpy"
+    nx: int,
+    ny: int,
+    nz: int,
+    nhalo: int,
+    etafile: Path,
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend
@@ -102,8 +108,8 @@ def states_from_fortran_restarts(
 
 
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_satmedmf_runs(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_satmedmf_runs(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/integration/test_satmedmf.py
+++ b/tests/integration/test_satmedmf.py
@@ -8,6 +8,7 @@ import ndsl.constants as constants
 import pyshield.constants as physcons
 from ndsl import NullComm, Quantity, QuantityFactory, StencilFactory, TileCommunicator
 from ndsl.boilerplate import get_factories_single_tile
+from ndsl.config import Backend, backend_python
 from ndsl.grid import (
     AngleGridData,
     ContravariantGridData,
@@ -21,7 +22,12 @@ from pyshield.stencils.pbl import PBLConfig
 
 
 def setup_infrastructure(
-    nx: int, ny: int, nz: int, nhalo: int, etafile: Path, backend: str = "numpy"
+    nx: int,
+    ny: int,
+    nz: int,
+    nhalo: int,
+    etafile: Path,
+    backend: Backend = backend_python,
 ):
     stencil_factory, quantity_factory = get_factories_single_tile(
         nx=nx, ny=ny, nz=nz, nhalo=nhalo, backend=backend
@@ -105,8 +111,8 @@ def states_from_fortran_restarts(
 
 
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_pyshield_runswith_satmedmf(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_pyshield_runswith_satmedmf(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -143,7 +143,7 @@ def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
         tile_rank=communicator.tile.rank,
         backend=backend,
     )
-    qf_soil = QuantityFactory(soil_sizer, backend="numpy")
+    qf_soil = QuantityFactory(soil_sizer, backend=Backend("st:numpy:cpu:IJK"))
 
     comconf = CompilationConfig()
     comconf.validate_args = False

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -18,7 +18,7 @@ from ndsl import (
     TileCommunicator,
 )
 from ndsl.config import Backend
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.typing import Float, Int
 from ndsl.grid import (
     AngleGridData,
@@ -200,14 +200,14 @@ def test_sfc_runs(restart_path: Path):
 
     def make_quantity_2d() -> Quantity:
         return quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
 
     def make_quantity_3d() -> Quantity:
         return quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -235,7 +235,7 @@ def test_sfc_runs(restart_path: Path):
     phil = make_quantity_3d()
     phil.field[:] = state.phil.field[:, :, ::-1]
     prsik = quantity_factory.zeros(
-        [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+        [I_DIM, J_DIM, K_INTERFACE_DIM],
         units="unknown",
         dtype=Float,
     )

--- a/tests/integration/test_sfc.py
+++ b/tests/integration/test_sfc.py
@@ -17,6 +17,7 @@ from ndsl import (
     SubtileGridSizer,
     TileCommunicator,
 )
+from ndsl.config import Backend
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.typing import Float, Int
 from ndsl.grid import (
@@ -113,7 +114,7 @@ def states_from_fortran_restarts(
 def setup_infrastructure(nx: Int, ny: Int, nz: Int, nzsoil: Int, etafile: Path):
     n_halo = 3
     rank = 0
-    backend = "numpy"
+    backend = Backend("st:numpy:cpu:IJK")
 
     comm = NullComm(rank, 1)
     communicator = TileCommunicator.from_layout(comm=comm, layout=(1, 1))
@@ -257,8 +258,8 @@ def test_sfc_runs(restart_path: Path):
 
 
 @pytest.mark.parametrize("restart_path", [Path("test_data/RESTART/")])
-@pytest.mark.parametrize("backend", ["numpy"])
-def test_pyshield_runswith_sfc(restart_path: Path, backend: str):
+@pytest.mark.parametrize("backend", [Backend("st:numpy:cpu:IJK")])
+def test_pyshield_runswith_sfc(restart_path: Path, backend: Backend):
     dycore_path = restart_path.joinpath("fv_core.res.tile1.nc")
     physics_path = restart_path.joinpath("phy_data.tile1.nc")
     sfc_path = restart_path.joinpath("sfc_data.tile1.nc")

--- a/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -14,7 +14,7 @@ GFSPhysicsDriver:
     max_error: 1e-10
   - backend: st:gt:gpu:KJI
     cuda_no_fma: true
-  - backend: st:dace:gpu:KJI
+  - backend: orch:dace:gpu:KIJ
     cuda_no_fma: true
     ignore_near_zero_errors:
       IPD_rain: 1e-12
@@ -36,7 +36,7 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
-  - backend: st:dace:gpu:KJI
+  - backend: orch:dace:gpu:KIJ
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
@@ -45,7 +45,7 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
-  - backend: st:dace:cpu:KIJ
+  - backend: orch:dace:cpu:KIJ
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -14,7 +14,7 @@ GFSPhysicsDriver:
     max_error: 1e-10
   - backend: st:gt:gpu:KJI
     cuda_no_fma: true
-  - backend: orch:dace:gpu:KIJ
+  - backend: orch:dace:gpu:KJI
     cuda_no_fma: true
     ignore_near_zero_errors:
       IPD_rain: 1e-12
@@ -36,7 +36,7 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
-  - backend: orch:dace:gpu:KIJ
+  - backend: orch:dace:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -8,15 +8,13 @@ Driver:
       cyd: 1e-3
 
 GFSPhysicsDriver:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     max_error: 1e-10
-  - backend: gt:cpu_ifirst
+  - backend: st:gt:cpu:KJI
     max_error: 1e-10
-  - backend: cuda
+  - backend: st:gt:gpu:KJI
     cuda_no_fma: true
-  - backend: gt:gpu
-    cuda_no_fma: true
-  - backend: dace:gpu
+  - backend: st:dace:gpu:KJI
     cuda_no_fma: true
     ignore_near_zero_errors:
       IPD_rain: 1e-12
@@ -27,20 +25,18 @@ GFSPhysicsDriver:
 # equivalent due to the use of fused multiply-add in the update stencil.
 # For validation we deactivate it (for validation only!)
 Microph:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     max_error: 2e-10
-  - backend: gt:cpu_ifirst
+  - backend: st:gt:cpu:KJI
     max_error: 6e-11
-  - backend: cuda
-    cuda_no_fma: true
-  - backend: gt:gpu
+  - backend: st:gt:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
-  - backend: dace:gpu
+  - backend: st:dace:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
@@ -49,7 +45,7 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
-  - backend: dace:cpu
+  - backend: st:dace:cpu:KIJ
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -10,7 +10,7 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
-  - backend: st:dace:cpu:KJI
+  - backend: orch:dace:cpu:KIJ
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
@@ -19,7 +19,7 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
-  - backend: st:dace:gpu:KJI
+  - backend: orch:dace:gpu:KIJ
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -10,7 +10,7 @@ Microph:
       mph_ql_dt: 1e-8
       mph_qr_dt: 1e-9
       mph_qg_dt: 1e-18
-  - backend: dace:cpu
+  - backend: st:dace:cpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
@@ -19,7 +19,7 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
-  - backend: dace:gpu
+  - backend: st:dace:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -19,7 +19,7 @@ Microph:
       mph_qg_dt: 1e-18
       mph_udt: 1e-8
       mph_vdt: 1e-8
-  - backend: orch:dace:gpu:KIJ
+  - backend: orch:dace:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -1,11 +1,9 @@
 Microph:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     max_error: 2e-9
-  - backend: gt:cpu_ifirst
+  - backend: st:gt:cpu:KJI
     max_error: 1e-12
-  - backend: cuda
-    cuda_no_fma: true
-  - backend: gt:gpu
+  - backend: st:gt:gpu:KJI
     max_error: 2.2e-8
     cuda_no_fma: true
     ignore_near_zero_errors:
@@ -32,10 +30,10 @@ Microph:
       mph_vdt: 1e-8
 
 SurfaceSeaIce_iter1:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     max_error: 2e-16
 Microphysics3:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     ignore_near_zero_errors:
       mp_qv: 1e-20
       mp_ql: 1e-20
@@ -45,7 +43,7 @@ Microphysics3:
       mp_qg: 1e-20
 
 Sedimentation:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     ignore_near_zero_errors:
       sd_qv: 1e-14
       sd_ql: 1e-14
@@ -66,7 +64,7 @@ Sedimentation:
       sd_dte: 1e-14
 
 TerminalFall:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     ignore_near_zero_errors:
       tf_qv: 1e-14
       tf_ql: 1e-14
@@ -83,12 +81,12 @@ TerminalFall:
       tf_dte: 1e-14
 
 WarmRain:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     ignore_near_zero_errors:
       wr_qr: 2e-7
 
 SubgridZProc:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     near_zero: 1.e-15
     ignore_near_zero_errors:
       - sz_qv
@@ -99,7 +97,7 @@ SubgridZProc:
       - sz_qg
 
 SubgridZSubs:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     near_zero: 1.e-15
     ignore_near_zero_errors:
       - szs_qv
@@ -110,7 +108,7 @@ SubgridZSubs:
       - szs_qg
 
 MPFull:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     near_zero: 1.e-20
     ignore_near_zero_errors:
       - mpf_qv
@@ -141,7 +139,7 @@ MPFull:
       - mpf_sub
 
 MPSub:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     near_zero: 1.e-20
     ignore_near_zero_errors:
       - mps_qv
@@ -152,7 +150,7 @@ MPSub:
       - mps_qg
 
 FinalCalculations:
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     near_zero: 1.e-20
     ignore_near_zero_errors:
       - column_energy_loss

--- a/tests/savepoint/translate/translate_atmos_phy_statein.py
+++ b/tests/savepoint/translate/translate_atmos_phy_statein.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import QuantityFactory, SubtileGridSizer
-from ndsl.constants import KAPPA, X_DIM, Y_DIM
+from ndsl.constants import I_DIM, J_DIM, KAPPA
 from pyshield.stencils.physics import atmos_phys_driver_statein
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
 
@@ -123,7 +123,7 @@ class TranslateAtmosPhysDriverStatein(TranslatePhysicsFortranData2Py):
         inputs["qsgs_tke"] = qsgs_tke
         inputs["dm"] = dm
         inputs["pgr"] = self.quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM], units="unknown"
+            dims=[I_DIM, J_DIM], units="unknown"
         )
         self.compute_func(**inputs)
         out = self.slice_output(inputs)

--- a/tests/savepoint/translate/translate_cloud_frac.py
+++ b/tests/savepoint/translate/translate_cloud_frac.py
@@ -1,7 +1,7 @@
 import pyshield.stencils.gfdl_cld_microphysics.constants as mpcons
 import pyshield.stencils.gfdl_cld_microphysics.physical_functions as physfun
 from ndsl import GridIndexing, QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
@@ -145,7 +145,7 @@ class CloudFractionTest:
     ):
         self._idx: GridIndexing = stencil_factory.grid_indexing
 
-        self._te = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._te = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
 
         self._cloud_fraction = stencil_factory.from_origin_domain(
             func=cloud_fraction_test,

--- a/tests/savepoint/translate/translate_cumulative_shalconv.py
+++ b/tests/savepoint/translate/translate_cumulative_shalconv.py
@@ -4,7 +4,7 @@ import numpy as np
 from gt4py.cartesian.gtscript import FORWARD, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import (
     Bool,
     BoolFieldIJ,
@@ -101,12 +101,12 @@ class InitCols:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -239,19 +239,19 @@ class Static1:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type=Float):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate arrays
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -301,19 +301,19 @@ class Static1:
         self._po = make_quantity()
 
         self._ctr = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ctro = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ecko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -321,12 +321,12 @@ class Static1:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_par_and_arr = stencil_factory.from_dims_halo(
             func=init_par_and_arr,
@@ -334,32 +334,32 @@ class Static1:
                 "asolfac": self._asolfac,
                 "c0s": self._c0s,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_kbm_kmax = stencil_factory.from_dims_halo(
             func=init_kbm_kmax,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_final = stencil_factory.from_dims_halo(
             func=init_final,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_tracers = stencil_factory.from_dims_halo(
             func=init_tracers,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static0 = stencil_factory.from_dims_halo(
             func=stencil_static0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static1 = stencil_factory.from_dims_halo(
             func=stencil_static1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic0 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -608,19 +608,19 @@ class Static2:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type=Float):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate arrays
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -714,31 +714,31 @@ class Static2:
         self._qevap = make_quantity_2D()
 
         self._ctr = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ctro = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ecko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._dellae = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._delebar = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -746,12 +746,12 @@ class Static2:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_par_and_arr = stencil_factory.from_dims_halo(
             func=init_par_and_arr,
@@ -759,36 +759,36 @@ class Static2:
                 "asolfac": self._asolfac,
                 "c0s": self._c0s,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_kbm_kmax = stencil_factory.from_dims_halo(
             func=init_kbm_kmax,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_final = stencil_factory.from_dims_halo(
             func=init_final,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_tracers = stencil_factory.from_dims_halo(
             func=init_tracers,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static0 = stencil_factory.from_dims_halo(
             func=stencil_static0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic0 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static1 = stencil_factory.from_dims_halo(
             func=stencil_static1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static2 = stencil_factory.from_dims_halo(
             func=stencil_static2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -1047,19 +1047,19 @@ class UpdateKB9:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type=Float):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate arrays
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1154,31 +1154,31 @@ class UpdateKB9:
         self._ptem = make_quantity_2D()
 
         self._ctr = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ctro = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ecko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._dellae = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._delebar = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -1186,12 +1186,12 @@ class UpdateKB9:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_par_and_arr = stencil_factory.from_dims_halo(
             func=init_par_and_arr,
@@ -1199,32 +1199,32 @@ class UpdateKB9:
                 "asolfac": self._asolfac,
                 "c0s": self._c0s,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_kbm_kmax = stencil_factory.from_dims_halo(
             func=init_kbm_kmax,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_final = stencil_factory.from_dims_halo(
             func=init_final,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_tracers = stencil_factory.from_dims_halo(
             func=init_tracers,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static0 = stencil_factory.from_dims_halo(
             func=stencil_static0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static1 = stencil_factory.from_dims_halo(
             func=stencil_static1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static2 = stencil_factory.from_dims_halo(
             func=stencil_static2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static3 = stencil_factory.from_dims_halo(
             func=stencil_static3,
@@ -1232,36 +1232,36 @@ class UpdateKB9:
                 "ntk": self._ntk,
                 "clam": self._clam,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic0 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static5 = stencil_factory.from_dims_halo(
             func=stencil_static5,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic1 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static7 = stencil_factory.from_dims_halo(
             func=stencil_static7,
             externals={"pgcon": self._pgcon},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic2 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_update_kbcon1_cnvflg = stencil_factory.from_dims_halo(
             func=stencil_update_kbcon1_cnvflg,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static9 = stencil_factory.from_dims_halo(
             func=stencil_static9,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -1629,19 +1629,19 @@ class Static10:
 
         def make_quantity():
             return quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type=Float):
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown", dtype=type)
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=type)
 
         # Allocate arrays
 
         # Layer mask:
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1727,31 +1727,31 @@ class Static10:
         self._ptem = make_quantity_2D()
 
         self._ctr = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ctro = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._ecko = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._dellae = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._delebar = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -1759,12 +1759,12 @@ class Static10:
         # Configure stencils
         self._pa_to_cb = stencil_factory.from_dims_halo(
             func=pa_to_cb,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_col_arr = stencil_factory.from_dims_halo(
             func=init_col_arr,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_par_and_arr = stencil_factory.from_dims_halo(
             func=init_par_and_arr,
@@ -1772,32 +1772,32 @@ class Static10:
                 "asolfac": self._asolfac,
                 "c0s": self._c0s,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_kbm_kmax = stencil_factory.from_dims_halo(
             func=init_kbm_kmax,
             externals={"km": self._km},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_final = stencil_factory.from_dims_halo(
             func=init_final,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._init_tracers = stencil_factory.from_dims_halo(
             func=init_tracers,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static0 = stencil_factory.from_dims_halo(
             func=stencil_static0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static1 = stencil_factory.from_dims_halo(
             func=stencil_static1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static2 = stencil_factory.from_dims_halo(
             func=stencil_static2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static3 = stencil_factory.from_dims_halo(
             func=stencil_static3,
@@ -1805,40 +1805,40 @@ class Static10:
                 "ntk": self._ntk,
                 "clam": self._clam,
             },
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic0 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic0,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static5 = stencil_factory.from_dims_halo(
             func=stencil_static5,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic1 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic1,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static7 = stencil_factory.from_dims_halo(
             func=stencil_static7,
             externals={"pgcon": self._pgcon},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_ntrstatic2 = stencil_factory.from_dims_halo(
             func=stencil_ntrstatic2,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_update_kbcon1_cnvflg = stencil_factory.from_dims_halo(
             func=stencil_update_kbcon1_cnvflg,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static9 = stencil_factory.from_dims_halo(
             func=stencil_static9,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
         self._stencil_static10 = stencil_factory.from_dims_halo(
             func=stencil_static10,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -3017,17 +3017,17 @@ class FeedbackCtrl:
         grid_indexing = stencil_factory.grid_indexing
 
         self._ud_mf = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._dt_mf = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -3037,7 +3037,7 @@ class FeedbackCtrl:
         self._feedback_control_update_mass_flux = stencil_factory.from_dims_halo(
             func=feedback_control_update_mass_flux,
             externals={"dt2": dt2},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -3142,7 +3142,7 @@ class SC13:
         grid_indexing = stencil_factory.grid_indexing
         self._ncloud = ncloud
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -3150,7 +3150,7 @@ class SC13:
             self._k_mask.data[:, :, k] = k
         self._stencil_static13 = stencil_factory.from_dims_halo(
             func=stencil_static13,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(
@@ -3186,13 +3186,13 @@ class CompTendencies:
         grid_indexing = stencil_factory.grid_indexing
         self._dt2 = dt2
         self._zi_ktcon = quantity_factory.zeros(
-            [X_DIM, Y_DIM], units="unknown", dtype=Float
+            [I_DIM, J_DIM], units="unknown", dtype=Float
         )
         self._zi_kbcon = quantity_factory.zeros(
-            [X_DIM, Y_DIM], units="unknown", dtype=Float
+            [I_DIM, J_DIM], units="unknown", dtype=Float
         )
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -3201,7 +3201,7 @@ class CompTendencies:
         self._comp_tendencies = stencil_factory.from_dims_halo(
             func=comp_tendencies,
             externals={"dt2": self._dt2},
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
     def __call__(

--- a/tests/savepoint/translate/translate_final_mp.py
+++ b/tests/savepoint/translate/translate_final_mp.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 from pyshield.stencils.gfdl_cld_microphysics.cloud_fraction import CloudFraction
 from pyshield.stencils.gfdl_cld_microphysics.gfdl_cld_mp_driver import (
@@ -34,11 +34,11 @@ class PostMP:
         self.do_sedi_uv = config.do_sedi_uv
         self.do_sedi_w = config.do_sedi_w
 
-        self._tzuv = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
-        self._tzw = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
-        self._qcon = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._tzuv = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
+        self._tzw = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
+        self._qcon = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
         self._cappa = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown"
         )
 
         if config.do_hail:
@@ -534,9 +534,9 @@ class FinalCalcs:
         self.do_sedi_uv = config.do_sedi_uv
         self.do_sedi_w = config.do_sedi_w
 
-        self._qcon = quantity_factory.zeros(dims=[X_DIM, Y_DIM, Z_DIM], units="unknown")
+        self._qcon = quantity_factory.zeros(dims=[I_DIM, J_DIM, K_DIM], units="unknown")
         self._cappa = quantity_factory.zeros(
-            dims=[X_DIM, Y_DIM, Z_DIM], units="unknown"
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown"
         )
 
         if config.consv_checker:

--- a/tests/savepoint/translate/translate_fpvs.py
+++ b/tests/savepoint/translate/translate_fpvs.py
@@ -2,7 +2,7 @@ import numpy as np
 from f90nml import Namelist
 
 from ndsl import StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from pyshield.functions.physics_functions import fpvs, fpvsx
@@ -56,7 +56,7 @@ class FPVS:
         xx = np.pad(xx, ((3, 4), (3, 4), (0, 1)))
         self._x = quantity_factory.from_array(
             xx,
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
         )
         grid_indexing = stencil_factory.grid_indexing

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -5,7 +5,7 @@ from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, StencilFactory
-from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, J_INTERFACE_DIM, K_DIM, X_INTERFACE_DIM
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.utils import safe_assign_array
 from pyshield.update import ApplyPhysicsToDycore
@@ -169,7 +169,7 @@ class TranslateFVUpdatePhys(ParallelPhysicsTranslate2Py):
             storage = inputs.pop(key)
             tendencies[key] = Quantity(
                 storage,
-                dims=[X_DIM, Y_DIM, Z_DIM],
+                dims=[I_DIM, J_DIM, K_DIM],
                 units="test",
                 origin=(0, 0, 0),
                 extent=storage.shape,
@@ -187,14 +187,14 @@ class TranslateFVUpdatePhys(ParallelPhysicsTranslate2Py):
             tendencies["u_dt"],
             tendencies["v_dt"],
         )
-        dims_u = [X_DIM, Y_INTERFACE_DIM, Z_DIM]
+        dims_u = [I_DIM, J_INTERFACE_DIM, K_DIM]
         u_quantity = self.grid.make_quantity(
             state.u,
             dims=dims_u,
             origin=self.grid.sizer.get_origin(dims_u),
             extent=self.grid.sizer.get_extent(dims_u),
         )
-        dims_v = [X_INTERFACE_DIM, Y_DIM, Z_DIM]
+        dims_v = [X_INTERFACE_DIM, J_DIM, K_DIM]
         v_quantity = self.grid.make_quantity(
             state.v,
             dims=dims_v,

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -5,7 +5,7 @@ from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, StencilFactory
-from ndsl.constants import I_DIM, J_DIM, J_INTERFACE_DIM, K_DIM, I_INTERFACE_DIM
+from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.utils import safe_assign_array
 from pyshield.update import ApplyPhysicsToDycore

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -5,7 +5,7 @@ from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, StencilFactory
-from ndsl.constants import I_DIM, J_DIM, J_INTERFACE_DIM, K_DIM, X_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, J_INTERFACE_DIM, K_DIM, I_INTERFACE_DIM
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.utils import safe_assign_array
 from pyshield.update import ApplyPhysicsToDycore
@@ -194,7 +194,7 @@ class TranslateFVUpdatePhys(ParallelPhysicsTranslate2Py):
             origin=self.grid.sizer.get_origin(dims_u),
             extent=self.grid.sizer.get_extent(dims_u),
         )
-        dims_v = [X_INTERFACE_DIM, J_DIM, K_DIM]
+        dims_v = [I_INTERFACE_DIM, J_DIM, K_DIM]
         v_quantity = self.grid.make_quantity(
             state.v,
             dims=dims_v,

--- a/tests/savepoint/translate/translate_mfpblt.py
+++ b/tests/savepoint/translate/translate_mfpblt.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Int
 from pyshield.stencils.pbl.mfpblt import PBLMassFlux
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
@@ -68,7 +68,7 @@ class TranslateMFPBLT(TranslatePhysicsFortranData2Py):
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -79,7 +79,7 @@ class TranslateMFPBLT(TranslatePhysicsFortranData2Py):
 
         cnvflg = quantity_factory.from_array(
             data=inputs.pop("cnvflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
         dt2 = (inputs["dt2"],)

--- a/tests/savepoint/translate/translate_mfscu.py
+++ b/tests/savepoint/translate/translate_mfscu.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Int
 from pyshield.stencils.pbl.mfscu import StratocumulusMassFlux
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
@@ -71,7 +71,7 @@ class TranslateMFSCU(TranslatePhysicsFortranData2Py):
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -81,17 +81,17 @@ class TranslateMFSCU(TranslatePhysicsFortranData2Py):
         inputs.pop("t1")
         cnvflg = quantity_factory.from_array(
             data=inputs.pop("cnvflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
         mrad = quantity_factory.from_array(
             data=inputs.pop("mrad"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
         zm = quantity_factory.from_array(
             data=inputs.pop("zm"),
-            dims=[X_DIM, Y_DIM, Z_DIM],
+            dims=[I_DIM, J_DIM, K_DIM],
             units="",
         )
         ntrac1 = int(inputs.pop("ntrac1"))

--- a/tests/savepoint/translate/translate_mp_full.py
+++ b/tests/savepoint/translate/translate_mp_full.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 from pyshield.stencils.gfdl_cld_microphysics.ice_cloud import IceCloud
 from pyshield.stencils.gfdl_cld_microphysics.mp_full import (
@@ -31,10 +31,10 @@ class SubMicrophysics:
         self._ntimes = config.ntimes
 
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="unknown")
 
         def make_quantity_2D():
-            return quantity_factory.zeros([X_DIM, Y_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM], units="unknown")
 
         self._fluxw = make_quantity()
         self._fluxr = make_quantity()

--- a/tests/savepoint/translate/translate_pbl_subtests.py
+++ b/tests/savepoint/translate/translate_pbl_subtests.py
@@ -1,7 +1,7 @@
 from gt4py.cartesian.gtscript import FORWARD, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import (
     Bool,
     BoolFieldIJ,
@@ -83,22 +83,22 @@ class InitTurb:
         self._kmpbl = idx.domain[2] // 2 + 1
         self._kmscu = idx.domain[2] // 2 + 1
         self._ptop = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="Pa",
             dtype=Float,
         )
         self._pbot = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="Pa",
             dtype=Float,
         )
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
         self._tem1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -326,7 +326,7 @@ class MRFScheme:
             domain=idx.domain_compute(),
         )
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -335,7 +335,7 @@ class MRFScheme:
             self._k_mask.data[:, :, k] = k
 
         self._thlvx_0 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -431,7 +431,7 @@ class ThermalPBL:
         self._kmpbl = idx.domain[2] // 2 + 1
         self._kmscu = idx.domain[2] // 2 + 1
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -440,7 +440,7 @@ class ThermalPBL:
             self._k_mask.data[:, :, k] = k
 
         self._thlvx_0 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -525,7 +525,7 @@ class Stratocumulus:
         self._kmpbl = idx.domain[2] // 2 + 1
         self._kmscu = idx.domain[2] // 2 + 1
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -578,23 +578,23 @@ class PBLAML:
         self._kmscu = idx.domain[2] // 2 + 1
 
         self._lev = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Int,
         )
 
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
         self._ptem = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._mlenflg = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Bool,
         )
@@ -663,7 +663,7 @@ class TKETridiag:
         self._dt_atmos = config.dt_atmos
         self._ntke = config.ntracers - 1
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -672,22 +672,22 @@ class TKETridiag:
             self._k_mask.data[:, :, k] = k
 
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._rt = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._f1_p1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
         self._ad_p1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -759,7 +759,7 @@ class Prandtl:
         idx = stencil_factory.grid_indexing
         self._kmpbl = idx.domain[2] // 2 + 1
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -845,12 +845,12 @@ class EdDiffShear:
     ):
         idx = stencil_factory.grid_indexing
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
         self._dkt_out = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -958,7 +958,7 @@ class UpDownTKE:
         self._ntke = config.ntracers - 1
 
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1025,14 +1025,14 @@ class MomentTridiagComp:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -1043,12 +1043,12 @@ class MomentTridiagComp:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._k_mask = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1157,14 +1157,14 @@ class HeatTracerTridiag:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -1175,12 +1175,12 @@ class HeatTracerTridiag:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._k_mask = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1309,7 +1309,7 @@ class TKETendencyCalc:
         self._rdt = 1.0 / self._dt_atmos
         self._ntke = config.ntracers - 1
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1318,22 +1318,22 @@ class TKETendencyCalc:
             self._k_mask.data[:, :, k] = k
 
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._rt = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._f1_p1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
         self._ad_p1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM],
+            [I_DIM, J_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -1457,14 +1457,14 @@ class HeatTracerTendencyCalc:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -1475,12 +1475,12 @@ class HeatTracerTendencyCalc:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._k_mask = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1675,14 +1675,14 @@ class MomentTendencyCalc:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -1693,12 +1693,12 @@ class MomentTendencyCalc:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
         self._k_mask = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1722,17 +1722,17 @@ class MomentTendencyCalc:
         )
 
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r2 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -1856,9 +1856,9 @@ class Half2:
         kmpbl: int,
     ):
         self._ntracers = config.ntracers
-        assert self._ntracers == 9, (
-            "PBL scheme satmedmfvdif requires ntracer " f"({config.ntracers}) == 9"
-        )
+        assert (
+            self._ntracers == 9
+        ), f"PBL scheme satmedmfvdif requires ntracer ({config.ntracers}) == 9"
 
         self._ntrac1 = self._ntracers - 1
 
@@ -1888,14 +1888,14 @@ class Half2:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -1906,13 +1906,13 @@ class Half2:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
 
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -1922,7 +1922,7 @@ class Half2:
         self._tem1 = make_quantity()
         self._lev = make_quantity_2D(Int)
         self._mlenflg = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Bool,
         )
@@ -2551,14 +2551,14 @@ class SCUEnd:
 
         def make_quantity():
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM, Z_DIM],
+                [I_DIM, J_DIM, K_DIM],
                 units="unknown",
                 dtype=Float,
             )
 
         def make_quantity_2D(type):
             return self.quantity_factory.zeros(
-                [X_DIM, Y_DIM],
+                [I_DIM, J_DIM],
                 units="unknown",
                 dtype=type,
             )
@@ -2569,7 +2569,7 @@ class SCUEnd:
         self._f1_p1 = make_quantity_2D(Float)
         self._f2_p1 = make_quantity_2D(Float)
         self._a2 = self.quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, self.TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, self.TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -2577,13 +2577,13 @@ class SCUEnd:
         self._tem1 = make_quantity()
         self._lev = make_quantity_2D(Int)
         self._mlenflg = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Bool,
         )
 
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -4640,13 +4640,13 @@ class TranslateHalf2(TranslatePhysicsFortranData2Py):
 
         pcnvflg = quantity_factory.from_array(
             data=inputs.pop("pcnvflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
 
         scuflg = quantity_factory.from_array(
             data=inputs.pop("scuflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
 
@@ -4882,13 +4882,13 @@ class TranslateSCUEnd(TranslatePhysicsFortranData2Py):
 
         pcnvflg = quantity_factory.from_array(
             data=inputs.pop("pcnvflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
 
         scuflg = quantity_factory.from_array(
             data=inputs.pop("scuflg"),
-            dims=[X_DIM, Y_DIM],
+            dims=[I_DIM, J_DIM],
             units="",
         )
 

--- a/tests/savepoint/translate/translate_preliminary_mp.py
+++ b/tests/savepoint/translate/translate_preliminary_mp.py
@@ -1,6 +1,6 @@
 import ndsl.stencils.basic_operations as basic
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM
+from ndsl.constants import I_DIM, J_DIM
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 from pyshield.stencils.gfdl_cld_microphysics.gfdl_cld_mp_driver import (
     calculate_density_factor,
@@ -33,7 +33,7 @@ class PrelimCalcs:
         self._tw_err = config.tw_err
 
         def make_quantity2d(**kwargs):
-            return quantity_factory.zeros(dims=[X_DIM, Y_DIM], units="unknown")
+            return quantity_factory.zeros(dims=[I_DIM, J_DIM], units="unknown")
 
         self._tot_energy_change = make_quantity2d()
         self._bottom_density = make_quantity2d()

--- a/tests/savepoint/translate/translate_sedimentation.py
+++ b/tests/savepoint/translate/translate_sedimentation.py
@@ -1,5 +1,5 @@
 from ndsl import Quantity, QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.typing import Int
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 from pyshield.stencils.gfdl_cld_microphysics.sedimentation import (
@@ -262,7 +262,7 @@ class SediMelt:
         self.c1_liq = config.c1_liq
         self.c1_ice = config.c1_ice
         self._k_mask = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM],
+            [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="unknown",
             dtype=Int,
         )
@@ -716,14 +716,14 @@ class TranslateSedimentation(TranslatePhysicsFortranData2Py):
             if len(inputs[var].shape) == 3:
                 inputs[var] = Quantity(
                     inputs[var],
-                    dims=[X_DIM, Y_DIM, Z_DIM],
+                    dims=[I_DIM, J_DIM, K_DIM],
                     units="unknown",
                     backend=self.quantity_factory.backend,
                 )
             elif len(inputs[var].shape) == 2:
                 inputs[var] = Quantity(
                     inputs[var],
-                    dims=[X_DIM, Y_DIM],
+                    dims=[I_DIM, J_DIM],
                     units="unknown",
                     backend=self.quantity_factory.backend,
                 )

--- a/tests/savepoint/translate/translate_tracer_sedi.py
+++ b/tests/savepoint/translate/translate_tracer_sedi.py
@@ -1,5 +1,5 @@
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from pyshield.stencils.gfdl_cld_microphysics import GFDLCloudMPConfig
 from pyshield.stencils.gfdl_cld_microphysics.sedimentation import (
     adjust_fluxes,
@@ -56,7 +56,7 @@ class TracerSedimentation:
 
         # allocate internal storages
         def make_quantity():
-            return quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], units="unknown")
+            return quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="unknown")
 
         self._cvm = make_quantity()
 

--- a/tests/savepoint/translate/translate_tridiag.py
+++ b/tests/savepoint/translate/translate_tridiag.py
@@ -1,7 +1,7 @@
 from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, SubtileGridSizer
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Float
 from ndsl.stencils.basic_operations import copy
 from pyshield._config import TRACER_DIM, FloatFieldTracer
@@ -25,12 +25,12 @@ class TridiT:
     ):
         idx = stencil_factory.grid_indexing
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._rt = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -95,17 +95,17 @@ class Tridi2:
         )
 
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r2 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, TRACER_DIM],
             units="unknown",
             dtype=Float,
         )
@@ -168,17 +168,17 @@ class TridiN:
         )
 
         self._cu = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r1 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM],
+            [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
         )
         self._r2 = quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_DIM, TRACER_DIM],
+            [I_DIM, J_DIM, K_DIM, TRACER_DIM],
             units="unknown",
             dtype=Float,
         )


### PR DESCRIPTION
**Description**

- [x] Allow python 3.12 and update CI to 3.12 
- [x] Backend string changed to `ndsl.Backend` object
- [x] Changed `X/Y/Z_DIM` to `I/J/K_DIM`
- [x] DaCe V2

:warning: Merging this PR depends on merging https://github.com/NOAA-GFDL/pyFV3/pull/120 first to get a version of pyFV3 that support python 3.12.
