### PR TITLE
deps: remove unused serialbox dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,10 @@ extras = [
   "pyshield[dev]",
   "pyshield[ndsl]",
   "pyshield[pyfv3]",
-  "pyshield[serialbox]",
   "pyshield[test]"
 ]
 ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.02.00"]
 pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
-serialbox = ["serialbox @ git+https://github.com/FlorianDeconinck/serialbox.git@feature/data_ijkbuff"]
 test = [
   "coverage",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,18 +35,19 @@ dev = [
   "flake8-pyproject"
 ]
 extras = [
-  "pyshield[test]",
+  "pyshield[dev]",
   "pyshield[ndsl]",
   "pyshield[pyfv3]",
-  "pyshield[dev]"
+  "pyshield[serialbox]",
+  "pyshield[test]"
 ]
 ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.02.00"]
 pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
+serialbox = ["serialbox @ git+https://github.com/FlorianDeconinck/serialbox.git@feature/data_ijkbuff"]
 test = [
+  "coverage",
   "pytest",
-  "pytest-subtests",
-  "serialbox",
-  "coverage"
+  "pytest-subtests"
 ]
 
 [project.urls]


### PR DESCRIPTION
**Description**

[Serialbox](https://github.com/GridTools/serialbox) is a serialization library that is used to build a validation framework against reference runs. At NASA/NOAA we use [this branch](https://github.com/FlorianDeconinck/serialbox/tree/feature/data_ijkbuff), which includes a couple of custom commands.

The currently configured [serialbox package](https://pypi.org/project/serialbox/) is about generating and distributing serial numbers. The fact that this misconfiguration never bothered anyone is surprising and hints at the fact that the serialbox serialization library is probably unused as part of the pySHiELD installation. In fact, `serialbox` isn't used anywhere in the source code of the pySHiELD repo. I thus suggest to just delete the dependency.

/cc @FlorianDeconinck as discussed

**How Has This Been Tested?**

Self-review of code plus passing existing tests.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
