### PR TITLE
[Update] Numpy 2x

### DIFF
--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_unit_tests:
-    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
+    uses: floriandeconinck/pace/.github/workflows/main_unit_tests.yaml@update/numpy_2x
     with:
       component_trigger: true
       component_name: pySHiELD

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -44,9 +44,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          repository: NOAA-GFDL/PySHiELD
+          repository: floriandeconinck/PySHiELD
           path: pySHiELD
-          ref: develop
+          ref: update/numpy_2x
 
       - name: 'Setup Python ${{ inputs.python_version && inputs.python_version || env.python_default }}'
         uses: actions/setup-python@v6
@@ -55,13 +55,6 @@ jobs:
 
       - name: Install mpi (MPICH flavor)
         run: pip install mpich
-
-      - name: Install numpy==1.26.4
-        # Front-load installing numpy to force its usage in the radiation
-        # scheme of pySHiELD.
-        # TODO: This is an ugly hack and it should be cleaned up latest once
-        #       we add support for numpy >= 2.0
-        run: pip install numpy==1.26.4
 
       - name: External trigger remove existing component in pySHiELD/develop
         if: ${{ inputs.component_name }}

--- a/examples/notebook/utilities.py
+++ b/examples/notebook/utilities.py
@@ -31,7 +31,7 @@ def states_from_fortran_restarts(
     tracer_data = xr.open_dataset(tracer_datafile)
 
     state = PhysicsState.init_zeros(quantity_factory, schemes)
-    radstate = RTE_RRTMGPState.init_zeros(quantity_factory, np)
+    radstate = RTE_RRTMGPState.init_zeros(quantity_factory)
     sstate = SurfaceState.init_zeros(quantity_factory)
 
     buff_3d = np.zeros_like(state.prsi.field)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ extras = [
   "pyshield[dev]"
 ]
 ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@update/numpy_2x"]
-pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/PyFV3.git@develop"]
+pyfv3 = ["pyfv3 @ git+https://github.com/floriandeconinck/PyFV3.git@update/numpy_2x"]
 test = [
   "pytest",
   "pytest-subtests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[dev]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.01.00"]
+ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@update/numpy_2x"]
 pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/PyFV3.git@develop"]
 test = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ extras = [
   "pyshield[test]"
 ]
 ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
-pyfv3 = ["pyfv3 @ git+https://github.com/floriandeconinck/PyFV3.git@update/numpy_2x"]
+pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
 test = [
   "coverage",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "f90nml>=1.1.0",
-  "numpy==1.26.4",
+  "numpy>=2",
   "xarray",
   "pyrte-rrtmgp @ git+https://github.com/NOAA-GFDL/pyRTE-RRTMGP.git@main"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/floriandeconinck/NDSL.git@update/numpy_2x"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
 pyfv3 = ["pyfv3 @ git+https://github.com/floriandeconinck/PyFV3.git@update/numpy_2x"]
 test = [
   "coverage",

--- a/pyshield/radiation/state.py
+++ b/pyshield/radiation/state.py
@@ -2,7 +2,6 @@ from dataclasses import InitVar, dataclass, field, fields
 from typing import Any, Dict, Mapping
 
 import numpy as np
-
 import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
@@ -295,7 +294,6 @@ class RTE_RRTMGPState:
         storages: Mapping[str, Any],
         sizer: GridSizer,
         quantity_factory: QuantityFactory,
-        np_like: NumpyModule,
     ) -> "RTE_RRTMGPState":
         inputs: Dict[str, Quantity] = {}
         for _field in fields(cls):

--- a/pyshield/radiation/state.py
+++ b/pyshield/radiation/state.py
@@ -1,13 +1,14 @@
 from dataclasses import InitVar, dataclass, field, fields
 from typing import Any, Dict, Mapping
 
+import numpy as np
+
 import xarray as xr
 
 import ndsl.dsl.gt4py_utils as gt_utils
 from ndsl import GridSizer, Quantity, QuantityFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.typing import Float
-from ndsl.types import NumpyModule
 
 
 @dataclass()
@@ -261,14 +262,11 @@ class RTE_RRTMGPState:
         }
     )
     quantity_factory: InitVar[QuantityFactory]
-    np_like: InitVar[NumpyModule]
 
     def __post_init__(
         self,
         quantity_factory: QuantityFactory,
-        np_like: NumpyModule,
     ):
-        self._np = np_like
         self._nz = quantity_factory.sizer.nz
         self._nx = quantity_factory.sizer.nx
         self._ny = quantity_factory.sizer.ny
@@ -277,7 +275,6 @@ class RTE_RRTMGPState:
     def init_zeros(
         cls,
         quantity_factory,
-        np_like: NumpyModule,
     ) -> "RTE_RRTMGPState":
         initial_arrays = {}
         for _field in fields(cls):
@@ -290,7 +287,6 @@ class RTE_RRTMGPState:
         return cls(
             **initial_arrays,
             quantity_factory=quantity_factory,
-            np_like=np_like,
         )
 
     @classmethod
@@ -323,7 +319,6 @@ class RTE_RRTMGPState:
         return cls(
             **inputs,
             quantity_factory=quantity_factory,
-            np_like=np_like,
         )
 
     @property
@@ -368,22 +363,22 @@ class RTE_RRTMGPState:
                             # dims.append(f"{dim_name}_{name}")
                             if dim_name == "z_interface":
                                 slice_list.append(
-                                    self._np.s_[:]  # type: ignore[attr-defined]
+                                    np.s_[:]  # type: ignore[attr-defined]
                                 )
                                 nz = self._nz + 1
                                 dims.append("level")
                             elif dim_name == "z":
                                 slice_list.append(
-                                    self._np.s_[:-1]  # type: ignore[attr-defined]
+                                    np.s_[:-1]  # type: ignore[attr-defined]
                                 )
                                 dims.append("layer")
                             elif "INTERFACE" in dim_name:
                                 slice_list.append(
-                                    self._np.s_[3:-3]  # type: ignore[attr-defined]
+                                    np.s_[3:-3]  # type: ignore[attr-defined]
                                 )
                             else:
                                 slice_list.append(
-                                    self._np.s_[3:-4]  # type: ignore[attr-defined]
+                                    np.s_[3:-4]  # type: ignore[attr-defined]
                                 )
                         # We have to reshape to get the max 2D shape rterrtmgp expects:
                         if ndims == 3:  # x-y-z array:

--- a/tests/integration/test_all.py
+++ b/tests/integration/test_all.py
@@ -81,7 +81,7 @@ def states_from_fortran_restarts(
     sfc_data = xr.open_dataset(sfc_datafile)
     state = PhysicsState.init_zeros(quantity_factory, schemes)
     sstate = SurfaceState.init_zeros(qf_sfc)
-    radstate = RTE_RRTMGPState.init_zeros(quantity_factory, np)
+    radstate = RTE_RRTMGPState.init_zeros(quantity_factory)
     buff_3d = np.zeros_like(state.prsi.field)
     npz = buff_3d.shape[2]
     for k in range(npz):

--- a/tests/integration/test_radiation_driver.py
+++ b/tests/integration/test_radiation_driver.py
@@ -102,7 +102,7 @@ def states_from_fortran_restarts(
     tracer_data = xr.open_dataset(tracer_datafile)
 
     state = PhysicsState.init_zeros(quantity_factory, schemes)
-    radstate = RTE_RRTMGPState.init_zeros(quantity_factory, np)
+    radstate = RTE_RRTMGPState.init_zeros(quantity_factory)
     sstate = SurfaceState.init_zeros(quantity_factory)
 
     buff_3d = np.zeros_like(state.prsi.field)
@@ -173,7 +173,7 @@ def test_rte_rrtmgp(datapath: Path):
     gridlon = grid_data.lon_agrid
     gridlat = grid_data.lat_agrid
 
-    state = RTE_RRTMGPState.init_zeros(quantity_factory, np)
+    state = RTE_RRTMGPState.init_zeros(quantity_factory)
     sstate = SurfaceState.init_zeros(quantity_factory)
     fortran_restart_to_radstate(
         dycore_datafile=dycore_data,


### PR DESCRIPTION
**Description**

~:bricks: :bricks: Merge post- https://github.com/NOAA-GFDL/NDSL/pull/389  :bricks: :bricks:~

[NDSL](https://github.com/NOAA-GFDL/NDSL/pull/389 ) `numpy` upgrade to 2x brings a few changes
- NDSL now requires `numpy>=2`  - we mirror the requirement here for `RRTMGP`
- Remove usage of `ndsl.types.NumpyModule`, it was only used for access to `np.s_` which id transparent to numpy/cupy

