### PR TITLE
[Update | CI] Restore link to Pace `develop`

### DIFF
--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_unit_tests:
-    uses: floriandeconinck/pace/.github/workflows/main_unit_tests.yaml@update/numpy_2x
+    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
     with:
       component_trigger: true
       component_name: pySHiELD

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -44,9 +44,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          repository: floriandeconinck/PySHiELD
+          repository: NOAA-GFDL/pySHiELD
           path: pySHiELD
-          ref: update/numpy_2x
 
       - name: 'Setup Python ${{ inputs.python_version && inputs.python_version || env.python_default }}'
         uses: actions/setup-python@v6


### PR DESCRIPTION
**Description**

Following https://github.com/NOAA-GFDL/pace/pull/182 we can rehook the CI upstream to Pace `develop` and downstream to pySHiELD `develop`