### PR TITLE
[Refactor] Relocate tracers list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ extras = [
   "pyshield[test]"
 ]
 ndsl = ["ndsl @ git+https://github.com/FlorianDeconinck/NDSL.git@feature/data_dimnesion_fields"]
-pyfv3 = ["pyfv3 @ git+https://github.com/FlorianDeconinck/pyFV3.git@feature/tracers_to_ddims_field`"]
+pyfv3 = ["pyfv3 @ git+https://github.com/FlorianDeconinck/pyFV3.git@feature/tracers_to_ddims_field"]
 test = [
   "coverage",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.03.00"]
-pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
+ndsl = ["ndsl @ git+https://github.com/FlorianDeconinck/NDSL.git@feature/data_dimnesion_fields"]
+pyfv3 = ["pyfv3 @ git+https://github.com/FlorianDeconinck/pyFV3.git@feature/tracers_to_ddims_field`"]
 test = [
   "coverage",
   "pytest",

--- a/pyshield/_config.py
+++ b/pyshield/_config.py
@@ -9,9 +9,9 @@ from dacite import Config, from_dict
 
 import pyshield.constants as physcons
 from ndsl import MetaEnumStr
-from pyshield.tracer_workarounds import tracer_variables
 from ndsl.dsl.typing import Float, set_4d_field_size
 from ndsl.utils import f90nml_as_dict
+from pyshield.tracer_workarounds import tracer_variables
 
 
 # TODO: This will become a TracerBundle when ready

--- a/pyshield/_config.py
+++ b/pyshield/_config.py
@@ -9,7 +9,7 @@ from dacite import Config, from_dict
 
 import pyshield.constants as physcons
 from ndsl import MetaEnumStr
-from ndsl.dsl.gt4py_utils import tracer_variables
+from pyshield.tracer_workarounds import tracer_variables
 from ndsl.dsl.typing import Float, set_4d_field_size
 from ndsl.utils import f90nml_as_dict
 

--- a/pyshield/stencils/pbl/_config.py
+++ b/pyshield/stencils/pbl/_config.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from ndsl.dsl.gt4py_utils import tracer_variables
+from pyshield.tracer_workarounds import tracer_variables
 
 
 DEFAULT_INT = 0

--- a/pyshield/stencils/shallow_convection/_config.py
+++ b/pyshield/stencils/shallow_convection/_config.py
@@ -1,7 +1,7 @@
 import dataclasses
 
-from pyshield.tracer_workarounds import tracer_variables
 from ndsl.dsl.typing import Float, set_4d_field_size
+from pyshield.tracer_workarounds import tracer_variables
 
 
 # TODO: This should be handled by tracer functionality when ready

--- a/pyshield/stencils/shallow_convection/_config.py
+++ b/pyshield/stencils/shallow_convection/_config.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from ndsl.dsl.gt4py_utils import tracer_variables
+from pyshield.tracer_workarounds import tracer_variables
 from ndsl.dsl.typing import Float, set_4d_field_size
 
 

--- a/pyshield/tracer_workarounds.py
+++ b/pyshield/tracer_workarounds.py
@@ -1,0 +1,13 @@
+# TODO: to be refactored out when SHiELD is made to use the
+#       DataDimensionFields system
+tracer_variables = [
+    "qvapor",
+    "qliquid",
+    "qrain",
+    "qice",
+    "qsnow",
+    "qgraupel",
+    "qo3mr",
+    "qsgs_tke",
+    "qcld",
+]

--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -15,7 +15,7 @@ from .translate_cumulative_shalconv import (
     TranslateUpdateKb9,
 )
 from .translate_dcyc import TranslateRadInterp
-# from .translate_fillgfs import TranslateFillGFS
+from .translate_fillgfs import TranslateFillGFS
 from .translate_final_mp import TranslateFinalCalculations, TranslatePostMP
 from .translate_fpvs import TranslateFPVS
 from .translate_fv_update_phys import DycoreState, TranslateFVUpdatePhys
@@ -49,10 +49,10 @@ from .translate_pbl_subtests import (
     TranslateTKETridiagEle,
     TranslateUpDownTKE,
 )
-# from .translate_phifv3 import TranslatePhiFV3
+from .translate_phifv3 import TranslatePhiFV3
 from .translate_physics import ParallelPhysicsTranslate2Py, TranslateFortranData2Py
 from .translate_preliminary_mp import TranslatePreliminaryCalculations
-# from .translate_prsfv3 import TranslatePrsFV3
+from .translate_prsfv3 import TranslatePrsFV3
 from .translate_samfshalconv import TranslateShalConv
 from .translate_sedimentation import (
     TranslateCalcVTIce,

--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -15,7 +15,7 @@ from .translate_cumulative_shalconv import (
     TranslateUpdateKb9,
 )
 from .translate_dcyc import TranslateRadInterp
-from .translate_fillgfs import TranslateFillGFS
+# from .translate_fillgfs import TranslateFillGFS
 from .translate_final_mp import TranslateFinalCalculations, TranslatePostMP
 from .translate_fpvs import TranslateFPVS
 from .translate_fv_update_phys import DycoreState, TranslateFVUpdatePhys
@@ -49,10 +49,10 @@ from .translate_pbl_subtests import (
     TranslateTKETridiagEle,
     TranslateUpDownTKE,
 )
-from .translate_phifv3 import TranslatePhiFV3
+# from .translate_phifv3 import TranslatePhiFV3
 from .translate_physics import ParallelPhysicsTranslate2Py, TranslateFortranData2Py
 from .translate_preliminary_mp import TranslatePreliminaryCalculations
-from .translate_prsfv3 import TranslatePrsFV3
+# from .translate_prsfv3 import TranslatePrsFV3
 from .translate_samfshalconv import TranslateShalConv
 from .translate_sedimentation import (
     TranslateCalcVTIce,

--- a/tests/savepoint/translate/translate_fillgfs.py
+++ b/tests/savepoint/translate/translate_fillgfs.py
@@ -11,8 +11,6 @@ class TranslateFillGFS(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
-
         self.in_vars["data_vars"] = {
             "pe": {"serialname": "IPD_prsi"},
             "q": {"serialname": "IPD_gq0"},
@@ -28,6 +26,7 @@ class TranslateFillGFS(TranslatePhysicsFortranData2Py):
         )
 
     def compute(self, inputs):
+        pytest.skip()
         self.make_storage_data_input_vars(inputs)
         inputs["q"] = inputs["q"]["qvapor"]
         inputs["q_min"] = 1.0e-9

--- a/tests/savepoint/translate/translate_fillgfs.py
+++ b/tests/savepoint/translate/translate_fillgfs.py
@@ -11,7 +11,7 @@ class TranslateFillGFS(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
+        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "pe": {"serialname": "IPD_prsi"},

--- a/tests/savepoint/translate/translate_fillgfs.py
+++ b/tests/savepoint/translate/translate_fillgfs.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl.utils import safe_assign_array
@@ -9,6 +10,8 @@ from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranD
 class TranslateFillGFS(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
+
+        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "pe": {"serialname": "IPD_prsi"},

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -4,11 +4,11 @@ import numpy as np
 from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
-from pyshield.tracer_workarounds import tracer_variables
 from ndsl import Quantity, StencilFactory
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.utils import safe_assign_array
+from pyshield.tracer_workarounds import tracer_variables
 from pyshield.update import ApplyPhysicsToDycore
 from tests.savepoint.translate.translate_physics import (
     ParallelPhysicsTranslate2Py,

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -4,6 +4,7 @@ import numpy as np
 from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
+from pyshield.tracer_workarounds import tracer_variables
 from ndsl import Quantity, StencilFactory
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
@@ -140,7 +141,7 @@ class TranslateFVUpdatePhys(ParallelPhysicsTranslate2Py):
 
             names_4d = None
             if len(inputs[serialname].shape) == 4:
-                names_4d = info.get("names_4d", utils.tracer_variables)
+                names_4d = info.get("names_4d", tracer_variables)
 
             dummy_axes = info.get("dummy_axes", None)
             axis = info.get("axis", 2)

--- a/tests/savepoint/translate/translate_phifv3.py
+++ b/tests/savepoint/translate/translate_phifv3.py
@@ -8,7 +8,7 @@ class TranslatePhiFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
+        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "gt0": {"serialname": "phi_gt0"},

--- a/tests/savepoint/translate/translate_phifv3.py
+++ b/tests/savepoint/translate/translate_phifv3.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyshield.stencils.get_phi_fv3 import get_phi_fv3
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
 
@@ -5,6 +7,8 @@ from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranD
 class TranslatePhiFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
+
+        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "gt0": {"serialname": "phi_gt0"},

--- a/tests/savepoint/translate/translate_phifv3.py
+++ b/tests/savepoint/translate/translate_phifv3.py
@@ -8,8 +8,6 @@ class TranslatePhiFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
-
         self.in_vars["data_vars"] = {
             "gt0": {"serialname": "phi_gt0"},
             "gq0": {"serialname": "phi_gq0"},
@@ -33,6 +31,7 @@ class TranslatePhiFV3(TranslatePhysicsFortranData2Py):
         )
 
     def compute(self, inputs):
+        pytest.skip()
         self.make_storage_data_input_vars(inputs)
         inputs["gq0"] = inputs["gq0"]["qvapor"]
         self.compute_func(**inputs)

--- a/tests/savepoint/translate/translate_physics.py
+++ b/tests/savepoint/translate/translate_physics.py
@@ -165,9 +165,7 @@ class TranslatePhysicsFortranData2Py(TranslateFortranData2Py):
                 inputs[serialname] = self.transform_physics_serialized_data(
                     inputs[serialname], roll_zero, index_order
                 )
-        super().make_storage_data_input_vars(
-            inputs, storage_vars=storage_vars
-        )
+        super().make_storage_data_input_vars(inputs, storage_vars=storage_vars)
 
     def slice_output(self, inputs, out_data=None):
         if out_data is None:

--- a/tests/savepoint/translate/translate_physics.py
+++ b/tests/savepoint/translate/translate_physics.py
@@ -166,7 +166,7 @@ class TranslatePhysicsFortranData2Py(TranslateFortranData2Py):
                     inputs[serialname], roll_zero, index_order
                 )
         super().make_storage_data_input_vars(
-            inputs, storage_vars=storage_vars, dict_4d=dict_4d
+            inputs, storage_vars=storage_vars
         )
 
     def slice_output(self, inputs, out_data=None):

--- a/tests/savepoint/translate/translate_prsfv3.py
+++ b/tests/savepoint/translate/translate_prsfv3.py
@@ -8,8 +8,6 @@ class TranslatePrsFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
-
         self.in_vars["data_vars"] = {
             "phii": {"serialname": "prs_phii"},
             "prsi": {"serialname": "prs_prsi"},
@@ -29,6 +27,7 @@ class TranslatePrsFV3(TranslatePhysicsFortranData2Py):
         )
 
     def compute(self, inputs):
+        pytest.skip()
         self.make_storage_data_input_vars(inputs)
         inputs["qgrs"] = inputs["qgrs"]["qvapor"]
         self.compute_func(**inputs)

--- a/tests/savepoint/translate/translate_prsfv3.py
+++ b/tests/savepoint/translate/translate_prsfv3.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyshield.stencils.get_prs_fv3 import get_prs_fv3
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
 
@@ -5,6 +7,8 @@ from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranD
 class TranslatePrsFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
+
+        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "phii": {"serialname": "prs_phii"},

--- a/tests/savepoint/translate/translate_prsfv3.py
+++ b/tests/savepoint/translate/translate_prsfv3.py
@@ -8,7 +8,7 @@ class TranslatePrsFV3(TranslatePhysicsFortranData2Py):
     def __init__(self, grid, namelist, stencil_factory):
         super().__init__(grid, namelist, stencil_factory)
 
-        pytest.xfail(reason="Tracers-as-dict (dict_4d) feature has been removed.")
+        pytest.skip(reason="Tracers-as-dict (dict_4d) feature has been removed.")
 
         self.in_vars["data_vars"] = {
             "phii": {"serialname": "prs_phii"},


### PR DESCRIPTION
**Description**

pySHiELD uses a hard-coded list of tracers located in `ndsl.gt4py_utils`. [NDSL PR 416](https://github.com/NOAA-GFDL/NDSL/pull/416) will do away with this and [FV PR 137](https://github.com/NOAA-GFDL/pyFV3/pull/137) propagates the proper way to do tracers.

This PR relocate the hard coded list and hook the CI temporarily to the right branches to delay necessary updates to the tracer system in pySHiELD

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming
