### PR TITLE
[CI] Re-hook develop of NDSL and pyfv3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ extras = [
   "pyshield[pyfv3]",
   "pyshield[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/FlorianDeconinck/NDSL.git@feature/data_dimnesion_fields"]
-pyfv3 = ["pyfv3 @ git+https://github.com/FlorianDeconinck/pyFV3.git@feature/tracers_to_ddims_field"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
+pyfv3 = ["pyfv3 @ git+https://github.com/NOAA-GFDL/pyFV3.git@develop"]
 test = [
   "coverage",
   "pytest",


### PR DESCRIPTION
Following https://github.com/NOAA-GFDL/NDSL/pull/416 we hook again upstream and dowstream repository to the `develop` branches.