### PR TITLE
ci: update pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,40 +2,43 @@ default_language_version:
   python: python3
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  # Use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
     hooks:
-      - id: black
+      - id: black-jupyter
+        additional_dependencies: ["black[jupyter]"]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+    rev: v2.3.0
     hooks:
       - id: mypy
-        name: mypy-physics
         args: ["--config-file", "pyproject.toml"]
+        additional_dependencies: [types-PyYAML]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:
       - id: flake8
         name: flake8
         language_version: python3
-        additional_dependencies: [Flake8-pyproject]
+        additional_dependencies: [Flake8-pyproject, flake8-bugbear]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.15.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix, --indent, "2"]

--- a/examples/notebook/test_physics.ipynb
+++ b/examples/notebook/test_physics.ipynb
@@ -100,8 +100,8 @@
     "    TilePartitioner,\n",
     "    WrappedHaloUpdater,\n",
     ")\n",
-    "from ndsl.constants import I_DIM, J_DIM, K_DIM \n",
-    "from ndsl.typing import Communicator "
+    "from ndsl.constants import I_DIM, J_DIM, K_DIM\n",
+    "from ndsl.typing import Communicator"
    ]
   },
   {
@@ -130,9 +130,13 @@
     "\n",
     "compilation_config = CompilationConfig(backend=backend, communicator=cs_communicator)\n",
     "\n",
-    "stencil_config = StencilConfig(compare_to_numpy=False, compilation_config=compilation_config)\n",
+    "stencil_config = StencilConfig(\n",
+    "    compare_to_numpy=False, compilation_config=compilation_config\n",
+    ")\n",
     "\n",
-    "grid_indexing = GridIndexing.from_sizer_and_communicator(sizer=sizer, comm=cs_communicator)\n",
+    "grid_indexing = GridIndexing.from_sizer_and_communicator(\n",
+    "    sizer=sizer, comm=cs_communicator\n",
+    ")\n",
     "\n",
     "stencil_factory = StencilFactory(config=stencil_config, grid_indexing=grid_indexing)"
    ]
@@ -154,6 +158,7 @@
    "source": [
     "from pyshield.stencils.physics import forward_euler\n",
     "\n",
+    "\n",
     "def euler_stencil(q: FloatField, qt: FloatField, dt: Float):\n",
     "    with computation(PARALLEL), interval(...):\n",
     "        q = forward_euler(q, qt, dt)"
@@ -172,7 +177,7 @@
     "dt = 0.5\n",
     "\n",
     "test_stencil = stencil_factory.from_origin_domain(\n",
-    "    func = euler_stencil,\n",
+    "    func=euler_stencil,\n",
     "    origin=grid_indexing.origin_compute(),\n",
     "    domain=grid_indexing.domain_compute(),\n",
     ")"
@@ -196,7 +201,7 @@
     "test_stencil(qq, qt, dt)\n",
     "\n",
     "if mpi_rank == 0:\n",
-    "    print(qq[:,:,0])"
+    "    print(qq[:, :, 0])"
    ]
   },
   {

--- a/examples/notebook/test_rad.ipynb
+++ b/examples/notebook/test_rad.ipynb
@@ -37,7 +37,15 @@
    "source": [
     "import xarray as xr\n",
     "import ndsl.dsl.gt4py_utils as gt_utils\n",
-    "from ndsl import GridSizer, Quantity, QuantityFactory, TileCommunicator, TilePartitioner, NullComm, SubtileGridSizer\n",
+    "from ndsl import (\n",
+    "    GridSizer,\n",
+    "    Quantity,\n",
+    "    QuantityFactory,\n",
+    "    TileCommunicator,\n",
+    "    TilePartitioner,\n",
+    "    NullComm,\n",
+    "    SubtileGridSizer,\n",
+    ")\n",
     "import ndsl.constants as constants\n",
     "\n",
     "from pyshield.radiation.state import RTE_RRTMGPState\n",
@@ -74,10 +82,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nx_tile=20\n",
-    "ny_tile=20\n",
-    "nz=79\n",
-    "n_halo=3"
+    "nx_tile = 20\n",
+    "ny_tile = 20\n",
+    "nz = 79\n",
+    "n_halo = 3"
    ]
   },
   {
@@ -91,7 +99,7 @@
     "backend = \"numpy\"\n",
     "\n",
     "comm = NullComm(rank, 1)\n",
-    "communicator = TileCommunicator.from_layout(comm=comm, layout=(1,1))\n",
+    "communicator = TileCommunicator.from_layout(comm=comm, layout=(1, 1))\n",
     "\n",
     "sizer = SubtileGridSizer.from_tile_params(\n",
     "    nx_tile=nx_tile,\n",
@@ -99,10 +107,10 @@
     "    nz=nz,\n",
     "    n_halo=n_halo,\n",
     "    extra_dim_lengths={},\n",
-    "    layout=(1,1),\n",
+    "    layout=(1, 1),\n",
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
-    "    backend=backend\n",
+    "    backend=backend,\n",
     ")\n",
     "quantity_factory = QuantityFactory(sizer, backend=backend)"
    ]
@@ -136,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p_lay = pkz[:,:,::-1]** (1./constants.KAPPA)"
+    "p_lay = pkz[:, :, ::-1] ** (1.0 / constants.KAPPA)"
    ]
   },
   {
@@ -350,16 +358,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prsi = ds.prsi.values[3:-4,3:-4,::-1] # level pressure\n",
-    "pt = ds.pt.values[3:-4,3:-4,-2::-1] # Layer temperature\n",
-    "delp = ds.delp.values[3:-4,3:-4,-2::-1]\n",
-    "delz = -1.* ds.delz.values[3:-4,3:-4,-2::-1]\n",
-    "dz = -1.* ds.dz.values[3:-4,3:-4,-2::-1]\n",
-    "qvap = ds.qvapor.values[3:-4,3:-4,-2::-1]\n",
-    "qliq = ds.qliquid.values[3:-4,3:-4,-2::-1]\n",
-    "qice = ds.qice.values[3:-4,3:-4,-2::-1]\n",
-    "qcld = ds.qcld.values[3:-4,3:-4,-2::-1]\n",
-    "phii = ds.phii.values[3:-4,3:-4,::-1]"
+    "prsi = ds.prsi.values[3:-4, 3:-4, ::-1]  # level pressure\n",
+    "pt = ds.pt.values[3:-4, 3:-4, -2::-1]  # Layer temperature\n",
+    "delp = ds.delp.values[3:-4, 3:-4, -2::-1]\n",
+    "delz = -1.0 * ds.delz.values[3:-4, 3:-4, -2::-1]\n",
+    "dz = -1.0 * ds.dz.values[3:-4, 3:-4, -2::-1]\n",
+    "qvap = ds.qvapor.values[3:-4, 3:-4, -2::-1]\n",
+    "qliq = ds.qliquid.values[3:-4, 3:-4, -2::-1]\n",
+    "qice = ds.qice.values[3:-4, 3:-4, -2::-1]\n",
+    "qcld = ds.qcld.values[3:-4, 3:-4, -2::-1]\n",
+    "phii = ds.phii.values[3:-4, 3:-4, ::-1]"
    ]
   },
   {
@@ -474,7 +482,7 @@
     }
    ],
    "source": [
-    "prsl = (prsi[:,:,1:] - prsi[:,:,:-1]) / np.log(prsi[:,:,1:] / prsi[:,:,:-1])\n",
+    "prsl = (prsi[:, :, 1:] - prsi[:, :, :-1]) / np.log(prsi[:, :, 1:] / prsi[:, :, :-1])\n",
     "prsl"
    ]
   },
@@ -515,9 +523,11 @@
    "outputs": [],
    "source": [
     "ptlev = np.zeros_like(prsi)\n",
-    "ptlev[:,:,1:-1] = pt[:,:,:-1] + (pt[:,:,1:] - pt[:,:,:-1]) * (np.log(prsi[:,:,1:-1]) - np.log(prsl[:,:,:-1])) / (np.log(prsl[:,:,1:]) - np.log(prsl[:,:,:-1]))\n",
-    "ptlev[:,:,-1] = pt[:,:,-1]\n",
-    "ptlev[:,:,0] = pt[:,:,0]"
+    "ptlev[:, :, 1:-1] = pt[:, :, :-1] + (pt[:, :, 1:] - pt[:, :, :-1]) * (\n",
+    "    np.log(prsi[:, :, 1:-1]) - np.log(prsl[:, :, :-1])\n",
+    ") / (np.log(prsl[:, :, 1:]) - np.log(prsl[:, :, :-1]))\n",
+    "ptlev[:, :, -1] = pt[:, :, -1]\n",
+    "ptlev[:, :, 0] = pt[:, :, 0]"
    ]
   },
   {
@@ -528,7 +538,7 @@
    "outputs": [],
    "source": [
     "qo3mr = ds.qo3mr.values\n",
-    "tskin = ptlev[:,:,-1]"
+    "tskin = ptlev[:, :, -1]"
    ]
   },
   {
@@ -577,7 +587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mu = np.sin(np.arange(400) * np.pi / 400.) - 0.3"
+    "mu = np.sin(np.arange(400) * np.pi / 400.0) - 0.3"
    ]
   },
   {
@@ -2049,19 +2059,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cloud_optics_lw = CloudOptics(\n",
-    "    cloud_optics_file=CloudOpticsFiles.LW_BND\n",
-    ")\n",
-    "gas_optics_lw = GasOptics(\n",
-    "    gas_optics_file=GasOpticsFiles.LW_G256\n",
-    ")\n",
+    "cloud_optics_lw = CloudOptics(cloud_optics_file=CloudOpticsFiles.LW_BND)\n",
+    "gas_optics_lw = GasOptics(gas_optics_file=GasOpticsFiles.LW_G256)\n",
     "\n",
-    "cloud_optics_sw = CloudOptics(\n",
-    "    cloud_optics_file=CloudOpticsFiles.SW_BND\n",
-    ")\n",
-    "gas_optics_sw = GasOptics(\n",
-    "    gas_optics_file=GasOpticsFiles.SW_G224\n",
-    ")"
+    "cloud_optics_sw = CloudOptics(cloud_optics_file=CloudOpticsFiles.SW_BND)\n",
+    "gas_optics_sw = GasOptics(gas_optics_file=GasOpticsFiles.SW_G224)"
    ]
   },
   {
@@ -2074,11 +2076,11 @@
     "gas_mapping = {\n",
     "    \"h2o\": \"qvapor\",\n",
     "    \"o3\": \"qo3mr\",\n",
-    "    'co':'co',\n",
-    "    'n2o': 'n2o',\n",
-    "    'o2': 'o2',\n",
-    "    'co2': 'co2',\n",
-    "    'n2': 'n2'\n",
+    "    \"co\": \"co\",\n",
+    "    \"n2o\": \"n2o\",\n",
+    "    \"o2\": \"o2\",\n",
+    "    \"co2\": \"co2\",\n",
+    "    \"n2\": \"n2\",\n",
     "}\n",
     "var_mapping = {\n",
     "    \"pres_layer\": \"prsl\",\n",
@@ -2091,9 +2093,12 @@
     "    \"surface_albedo_direct\": \"surface_albedo_direct\",\n",
     "    \"surface_albedo_diffuse\": \"surface_albedo_diffuse\",\n",
     "    \"surface_emissivity\": \"surface_emissivity\",\n",
-    "    \"surface_emissivity_jacobian\": \"surface_emissivity_jacobian\",   \n",
+    "    \"surface_emissivity_jacobian\": \"surface_emissivity_jacobian\",\n",
     "}\n",
-    "atm_map = AtmosphericMapping(dim_mapping=DEFAULT_DIM_MAPPING, var_mapping=var_mapping,)"
+    "atm_map = AtmosphericMapping(\n",
+    "    dim_mapping=DEFAULT_DIM_MAPPING,\n",
+    "    var_mapping=var_mapping,\n",
+    ")"
    ]
   },
   {
@@ -2112,13 +2117,12 @@
    "outputs": [],
    "source": [
     "optical_props = gas_optics_lw.compute(\n",
-    "    xds, \n",
+    "    xds,\n",
     "    problem_type=rte.OpticsTypes.ABSORPTION,\n",
     "    add_to_input=False,\n",
     "    gas_name_map=gas_mapping,\n",
     "    variable_mapping=atm_map,\n",
-    ")\n",
-    "\n"
+    ")"
    ]
   },
   {
@@ -3178,8 +3182,10 @@
     }
    ],
    "source": [
-    "plt.plot(clr_fluxes_lw.lw_flux_up.isel(column=0),   clr_fluxes_lw.level, label=\"Flux up\")\n",
-    "plt.plot(clr_fluxes_lw.lw_flux_down.isel(column=0), clr_fluxes_lw.level, label=\"Flux down\")\n",
+    "plt.plot(clr_fluxes_lw.lw_flux_up.isel(column=0), clr_fluxes_lw.level, label=\"Flux up\")\n",
+    "plt.plot(\n",
+    "    clr_fluxes_lw.lw_flux_down.isel(column=0), clr_fluxes_lw.level, label=\"Flux down\"\n",
+    ")\n",
     "plt.legend(frameon=False)"
    ]
   },
@@ -3755,7 +3761,7 @@
    ],
    "source": [
     "sw_optics = gas_optics_sw.compute(\n",
-    "    xds, \n",
+    "    xds,\n",
     "    problem_type=rte.OpticsTypes.TWO_STREAM,\n",
     "    add_to_input=False,\n",
     "    gas_name_map=gas_mapping,\n",
@@ -3804,10 +3810,24 @@
     }
    ],
    "source": [
-    "plt.plot(fluxes_sw.sw_flux_up.isel(column=0), fluxes_sw.level, label=\"night SW clear flux up\")\n",
-    "plt.plot(fluxes_sw.sw_flux_down.isel(column=0), fluxes_sw.level, label=\"night SW clear flux down\")\n",
-    "plt.plot(fluxes_sw.sw_flux_up.isel(column=200), fluxes_sw.level, label=\"noon SW clear flux up\")\n",
-    "plt.plot(fluxes_sw.sw_flux_down.isel(column=200), fluxes_sw.level, label=\"noon SW clear flux down\")\n",
+    "plt.plot(\n",
+    "    fluxes_sw.sw_flux_up.isel(column=0), fluxes_sw.level, label=\"night SW clear flux up\"\n",
+    ")\n",
+    "plt.plot(\n",
+    "    fluxes_sw.sw_flux_down.isel(column=0),\n",
+    "    fluxes_sw.level,\n",
+    "    label=\"night SW clear flux down\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    fluxes_sw.sw_flux_up.isel(column=200),\n",
+    "    fluxes_sw.level,\n",
+    "    label=\"noon SW clear flux up\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    fluxes_sw.sw_flux_down.isel(column=200),\n",
+    "    fluxes_sw.level,\n",
+    "    label=\"noon SW clear flux down\",\n",
+    ")\n",
     "plt.legend(frameon=False)"
    ]
   },

--- a/examples/notebook/test_rad_data.ipynb
+++ b/examples/notebook/test_rad_data.ipynb
@@ -81,7 +81,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "quantity_factory, stencil_factory, grid_data = setup_infrastructure(nx, ny, nz, \"eta91.nc\")"
+    "quantity_factory, stencil_factory, grid_data = setup_infrastructure(\n",
+    "    nx, ny, nz, \"eta91.nc\"\n",
+    ")"
    ]
   },
   {
@@ -92,8 +94,8 @@
    "outputs": [],
    "source": [
     "# Quick fix:\n",
-    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1,:-1]\n",
-    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1,:-1]"
+    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1, :-1]\n",
+    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1, :-1]"
    ]
   },
   {
@@ -105,8 +107,8 @@
    "source": [
     "conf = PhysicsConfig\n",
     "radconf = RTE_RRTMGPConfig(\n",
-    "    deltsw = 3600.0,\n",
-    "    delt_rad = 3600.0,\n",
+    "    deltsw=3600.0,\n",
+    "    delt_rad=3600.0,\n",
     "    date=date,\n",
     "    fhswr=1.0,\n",
     "    fhlwr=1.0,\n",
@@ -177,7 +179,14 @@
    ],
    "source": [
     "%%time\n",
-    "rad = RTE_RRTMGPDriver(config=radconf, gridlon=gridlon, gridlat=gridlat, sigma=sigma, quantity_factory=quantity_factory, stencil_factory=stencil_factory)"
+    "rad = RTE_RRTMGPDriver(\n",
+    "    config=radconf,\n",
+    "    gridlon=gridlon,\n",
+    "    gridlat=gridlat,\n",
+    "    sigma=sigma,\n",
+    "    quantity_factory=quantity_factory,\n",
+    "    stencil_factory=stencil_factory,\n",
+    ")"
    ]
   },
   {
@@ -198,7 +207,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fortran_restart_to_radstate(dycore_datafile=dycore_data, phys_datafile=phys_data, tracer_datafile=tracer_data, ak=grid_data.ak, state=state)"
+    "fortran_restart_to_radstate(\n",
+    "    dycore_datafile=dycore_data,\n",
+    "    phys_datafile=phys_data,\n",
+    "    tracer_datafile=tracer_data,\n",
+    "    ak=grid_data.ak,\n",
+    "    state=state,\n",
+    ")"
    ]
   },
   {
@@ -239,11 +254,18 @@
     }
    ],
    "source": [
-    "xcol, ycol = np.unravel_index(np.argmax(state.qcld.field.sum(axis=2) + state.qliquid.field.sum(axis=2) + state.qice.field.sum(axis=2)), state.qliquid.field.sum(axis=2).shape)\n",
+    "xcol, ycol = np.unravel_index(\n",
+    "    np.argmax(\n",
+    "        state.qcld.field.sum(axis=2)\n",
+    "        + state.qliquid.field.sum(axis=2)\n",
+    "        + state.qice.field.sum(axis=2)\n",
+    "    ),\n",
+    "    state.qliquid.field.sum(axis=2).shape,\n",
+    ")\n",
     "# xcol, ycol = np.unravel_index(np.argmax(state.qliquid.field.sum(axis=2) + state.qice.field.sum(axis=2)), state.qliquid.field.sum(axis=2).shape)\n",
     "print(xcol, ycol)\n",
-    "print(state.qliquid.field[xcol,ycol,:].sum())\n",
-    "print(gridlon.field[xcol,ycol]*180/3.141, gridlat.field[xcol, ycol]*180/3.141)\n",
+    "print(state.qliquid.field[xcol, ycol, :].sum())\n",
+    "print(gridlon.field[xcol, ycol] * 180 / 3.141, gridlat.field[xcol, ycol] * 180 / 3.141)\n",
     "print(f\"{date} UTC\")"
    ]
   },
@@ -275,17 +297,30 @@
     }
    ],
    "source": [
-    "fig0 = plt.figure(0, figsize = (13,13))    #create  figure\n",
-    "f0ax1 = fig0.add_subplot(111) # define axes in which to plot\n",
+    "fig0 = plt.figure(0, figsize=(13, 13))  # create  figure\n",
+    "f0ax1 = fig0.add_subplot(111)  # define axes in which to plot\n",
     "f0ax1.yaxis.set_inverted(True)\n",
     "f0ax1.set_xlabel(\"flux (W/m^2)\")\n",
     "f0ax1.set_ylabel(\"pressure (hPa)\")\n",
-    "f0ax1.plot(state.fswd.field[xcol, ycol,:], state.prsi.field[xcol, ycol, :]/100, label=\"SW all-sky flux Down\")\n",
-    "f0ax1.plot(state.fswu.field[xcol, ycol,:], state.prsi.field[xcol, ycol, :]/100, label=\"SW all-sky flux Up\")\n",
+    "f0ax1.plot(\n",
+    "    state.fswd.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"SW all-sky flux Down\",\n",
+    ")\n",
+    "f0ax1.plot(\n",
+    "    state.fswu.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"SW all-sky flux Up\",\n",
+    ")\n",
     "\n",
     "f0ax2 = f0ax1.twiny()\n",
     "f0ax2.set_xlabel(\"specific_humidity (kg/kg)\")\n",
-    "f0ax2.plot(state.qvapor.field[xcol, ycol,:], state.prsi.field[xcol, ycol,:-1]/100, label=\"qvapor\", color=\"m\")\n",
+    "f0ax2.plot(\n",
+    "    state.qvapor.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :-1] / 100,\n",
+    "    label=\"qvapor\",\n",
+    "    color=\"m\",\n",
+    ")\n",
     "\n",
     "fig0.legend(frameon=False, loc=4)"
    ]
@@ -318,17 +353,30 @@
     }
    ],
    "source": [
-    "fig1 = plt.figure(1, figsize = (13,13))    #create  figure\n",
-    "f1ax1 = fig1.add_subplot(111) # define axes in which to plot\n",
+    "fig1 = plt.figure(1, figsize=(13, 13))  # create  figure\n",
+    "f1ax1 = fig1.add_subplot(111)  # define axes in which to plot\n",
     "f1ax1.yaxis.set_inverted(True)\n",
     "f1ax1.set_xlabel(\"flux (W/m^2)\")\n",
     "f1ax1.set_ylabel(\"pressure (hPa)\")\n",
-    "f1ax1.plot(state.flwd.field[xcol, ycol,:], state.prsi.field[xcol, ycol, :]/100, label=\"LW all-sky flux Down\")\n",
-    "f1ax1.plot(state.flwu.field[xcol, ycol,:], state.prsi.field[xcol, ycol, :]/100, label=\"LW all-sky flux Up\")\n",
+    "f1ax1.plot(\n",
+    "    state.flwd.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"LW all-sky flux Down\",\n",
+    ")\n",
+    "f1ax1.plot(\n",
+    "    state.flwu.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"LW all-sky flux Up\",\n",
+    ")\n",
     "\n",
     "f1ax2 = f1ax1.twiny()\n",
     "f1ax2.set_xlabel(\"specific_humidity (kg/kg)\")\n",
-    "f1ax2.plot(state.qvapor.field[xcol, ycol,:], state.prsi.field[xcol, ycol,:-1]/100, label=\"qvapor\", color=\"m\")\n",
+    "f1ax2.plot(\n",
+    "    state.qvapor.field[xcol, ycol, :],\n",
+    "    state.prsi.field[xcol, ycol, :-1] / 100,\n",
+    "    label=\"qvapor\",\n",
+    "    color=\"m\",\n",
+    ")\n",
     "\n",
     "fig1.legend(frameon=False, loc=4)"
    ]
@@ -381,8 +429,8 @@
     }
    ],
    "source": [
-    "plt.plot(state.fswd.view[0,0,:], levels, label=\"SW all-sky flux Down\")\n",
-    "plt.plot(state.fswu.view[0,0,:], levels, label=\"SW all-sky flux Up\")\n",
+    "plt.plot(state.fswd.view[0, 0, :], levels, label=\"SW all-sky flux Down\")\n",
+    "plt.plot(state.fswu.view[0, 0, :], levels, label=\"SW all-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },
@@ -414,8 +462,8 @@
     }
    ],
    "source": [
-    "plt.plot(state.flwd.view[0,0,:], levels, label=\"LW all-sky flux Down\")\n",
-    "plt.plot(state.flwu.view[0,0,:], levels, label=\"LW all-sky flux Up\")\n",
+    "plt.plot(state.flwd.view[0, 0, :], levels, label=\"LW all-sky flux Down\")\n",
+    "plt.plot(state.flwu.view[0, 0, :], levels, label=\"LW all-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },

--- a/examples/notebook/test_radcall.ipynb
+++ b/examples/notebook/test_radcall.ipynb
@@ -81,10 +81,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "quantity_factory, stencil_factory, grid_data = setup_infrastructure(nx, ny, nz, \"eta91.nc\")\n",
+    "quantity_factory, stencil_factory, grid_data = setup_infrastructure(\n",
+    "    nx, ny, nz, \"eta91.nc\"\n",
+    ")\n",
     "# Quick fix:\n",
-    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1,:-1]\n",
-    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1,:-1]"
+    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1, :-1]\n",
+    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1, :-1]"
    ]
   },
   {
@@ -104,11 +106,11 @@
     "    nwat=6,\n",
     "    prescribe_sst=False,\n",
     "    schemes=[\"GFS_microphysics\", \"RTE_RRTMGP\"],\n",
-    "    hydro_delp=False\n",
+    "    hydro_delp=False,\n",
     ")\n",
     "radconf = RTE_RRTMGPConfig(\n",
-    "    deltsw = 3600.0,\n",
-    "    delt_rad = 3600.0,\n",
+    "    deltsw=3600.0,\n",
+    "    delt_rad=3600.0,\n",
     "    date=date,\n",
     "    fhswr=1.0,\n",
     "    fhlwr=1.0,\n",
@@ -139,7 +141,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state, radstate, sstate = states_from_fortran_restarts(dycore_data, phys_data, tracer_data, grid_data.ak, quantity_factory, conf.schemes)\n",
+    "state, radstate, sstate = states_from_fortran_restarts(\n",
+    "    dycore_data, phys_data, tracer_data, grid_data.ak, quantity_factory, conf.schemes\n",
+    ")\n",
     "# state.prsi.field[0, 0, :]"
    ]
   },
@@ -150,7 +154,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prsl = (state.prsi.field[:, :, 1:] - state.prsi.field[:, :, :-1]) / np.log(state.prsi.field[:, :, 1:] / state.prsi.field[:, :, :-1])\n",
+    "prsl = (state.prsi.field[:, :, 1:] - state.prsi.field[:, :, :-1]) / np.log(\n",
+    "    state.prsi.field[:, :, 1:] / state.prsi.field[:, :, :-1]\n",
+    ")\n",
     "# prsl[0,0,:]\n",
     "# state.delp.field[:] = prsl"
    ]
@@ -278,10 +284,16 @@
    ],
    "source": [
     "# xcol, ycol = np.unravel_index(np.argmax(radstate.qliquid.field.sum(axis=2) + radstate.qice.field.sum(axis=2)), radstate.qliquid.field.sum(axis=2).shape)\n",
-    "xcol, ycol, _ = np.unravel_index(np.argmax(radstate.qliquid.field[:] + radstate.qice.field[:]), radstate.qliquid.field.shape)\n",
+    "xcol, ycol, _ = np.unravel_index(\n",
+    "    np.argmax(radstate.qliquid.field[:] + radstate.qice.field[:]),\n",
+    "    radstate.qliquid.field.shape,\n",
+    ")\n",
     "print(xcol, ycol)\n",
-    "print(radstate.qliquid.field[xcol,ycol,:].sum())\n",
-    "print(grid_data.lon_agrid.field[xcol,ycol]*180/3.141, grid_data.lat_agrid.field[xcol, ycol]*180/3.141)\n",
+    "print(radstate.qliquid.field[xcol, ycol, :].sum())\n",
+    "print(\n",
+    "    grid_data.lon_agrid.field[xcol, ycol] * 180 / 3.141,\n",
+    "    grid_data.lat_agrid.field[xcol, ycol] * 180 / 3.141,\n",
+    ")\n",
     "print(f\"{date} UTC\")"
    ]
   },
@@ -313,17 +325,30 @@
     }
    ],
    "source": [
-    "fig0 = plt.figure(0, figsize = (13,13))    #create  figure\n",
-    "f0ax1 = fig0.add_subplot(111) # define axes in which to plot\n",
+    "fig0 = plt.figure(0, figsize=(13, 13))  # create  figure\n",
+    "f0ax1 = fig0.add_subplot(111)  # define axes in which to plot\n",
     "f0ax1.yaxis.set_inverted(True)\n",
     "f0ax1.set_xlabel(\"flux (W/m^2)\")\n",
     "f0ax1.set_ylabel(\"pressure (hPa)\")\n",
-    "f0ax1.plot(radstate.fswd.field[xcol, ycol,:], radstate.prsi.field[xcol, ycol, :]/100, label=\"SW all-sky flux Down\")\n",
-    "f0ax1.plot(radstate.fswu.field[xcol, ycol,:], radstate.prsi.field[xcol, ycol, :]/100, label=\"SW all-sky flux Up\")\n",
+    "f0ax1.plot(\n",
+    "    radstate.fswd.field[xcol, ycol, :],\n",
+    "    radstate.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"SW all-sky flux Down\",\n",
+    ")\n",
+    "f0ax1.plot(\n",
+    "    radstate.fswu.field[xcol, ycol, :],\n",
+    "    radstate.prsi.field[xcol, ycol, :] / 100,\n",
+    "    label=\"SW all-sky flux Up\",\n",
+    ")\n",
     "\n",
     "f0ax2 = f0ax1.twiny()\n",
     "f0ax2.set_xlabel(\"specific_humidity (kg/kg)\")\n",
-    "f0ax2.plot(radstate.qvapor.field[xcol, ycol,:], radstate.prsi.field[xcol, ycol,:-1]/100, label=\"qvapor\", color=\"m\")\n",
+    "f0ax2.plot(\n",
+    "    radstate.qvapor.field[xcol, ycol, :],\n",
+    "    radstate.prsi.field[xcol, ycol, :-1] / 100,\n",
+    "    label=\"qvapor\",\n",
+    "    color=\"m\",\n",
+    ")\n",
     "\n",
     "fig0.legend(frameon=False, loc=4)"
    ]
@@ -356,10 +381,10 @@
     }
    ],
    "source": [
-    "plt.plot(radstate.fswd.view[xcol, ycol,:], levels, label=\"SW all-sky flux Down\")\n",
-    "plt.plot(radstate.fswu.view[xcol, ycol,:], levels, label=\"SW all-sky flux Up\")\n",
-    "plt.plot(radstate.fswd_clr.view[xcol, ycol,:], levels, label=\"SW clear-sky flux Down\")\n",
-    "plt.plot(radstate.fswu_clr.view[xcol, ycol,:], levels, label=\"SW clear-sky flux Up\")\n",
+    "plt.plot(radstate.fswd.view[xcol, ycol, :], levels, label=\"SW all-sky flux Down\")\n",
+    "plt.plot(radstate.fswu.view[xcol, ycol, :], levels, label=\"SW all-sky flux Up\")\n",
+    "plt.plot(radstate.fswd_clr.view[xcol, ycol, :], levels, label=\"SW clear-sky flux Down\")\n",
+    "plt.plot(radstate.fswu_clr.view[xcol, ycol, :], levels, label=\"SW clear-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },
@@ -391,10 +416,10 @@
     }
    ],
    "source": [
-    "plt.plot(radstate.flwd.view[xcol, ycol,:], levels, label=\"LW all-sky flux Down\")\n",
-    "plt.plot(radstate.flwu.view[xcol, ycol,:], levels, label=\"LW all-sky flux Up\")\n",
-    "plt.plot(radstate.flwd_clr.view[xcol, ycol,:], levels, label=\"LW clear-sky flux Down\")\n",
-    "plt.plot(radstate.flwu_clr.view[xcol, ycol,:], levels, label=\"LW clear-sky flux Up\")\n",
+    "plt.plot(radstate.flwd.view[xcol, ycol, :], levels, label=\"LW all-sky flux Down\")\n",
+    "plt.plot(radstate.flwu.view[xcol, ycol, :], levels, label=\"LW all-sky flux Up\")\n",
+    "plt.plot(radstate.flwd_clr.view[xcol, ycol, :], levels, label=\"LW clear-sky flux Down\")\n",
+    "plt.plot(radstate.flwu_clr.view[xcol, ycol, :], levels, label=\"LW clear-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },

--- a/examples/notebook/test_raddriver.ipynb
+++ b/examples/notebook/test_raddriver.ipynb
@@ -29,7 +29,15 @@
    "source": [
     "import xarray as xr\n",
     "import ndsl.dsl.gt4py_utils as gt_utils\n",
-    "from ndsl import GridSizer, Quantity, QuantityFactory, TileCommunicator, TilePartitioner, NullComm, SubtileGridSizer\n",
+    "from ndsl import (\n",
+    "    GridSizer,\n",
+    "    Quantity,\n",
+    "    QuantityFactory,\n",
+    "    TileCommunicator,\n",
+    "    TilePartitioner,\n",
+    "    NullComm,\n",
+    "    SubtileGridSizer,\n",
+    ")\n",
     "import ndsl.constants as constants\n",
     "\n",
     "from pyshield.radiation import RTE_RRTMGPState, RTE_RRTMGPConfig, RTE_RRTMGPDriver\n",
@@ -59,10 +67,10 @@
    "outputs": [],
    "source": [
     "schemes = PHYSICS_PACKAGES\n",
-    "nx_tile=20\n",
-    "ny_tile=20\n",
-    "nz=79\n",
-    "n_halo=3\n",
+    "nx_tile = 20\n",
+    "ny_tile = 20\n",
+    "nz = 79\n",
+    "n_halo = 3\n",
     "date = datetime.datetime(2020, 1, 1, 12, tzinfo=datetime.timezone.utc)"
    ]
   },
@@ -77,7 +85,7 @@
     "backend = \"numpy\"\n",
     "\n",
     "comm = NullComm(rank, 1)\n",
-    "communicator = TileCommunicator.from_layout(comm=comm, layout=(1,1))\n",
+    "communicator = TileCommunicator.from_layout(comm=comm, layout=(1, 1))\n",
     "\n",
     "sizer = SubtileGridSizer.from_tile_params(\n",
     "    nx_tile=nx_tile,\n",
@@ -85,10 +93,10 @@
     "    nz=nz,\n",
     "    n_halo=n_halo,\n",
     "    extra_dim_lengths={},\n",
-    "    layout=(1,1),\n",
+    "    layout=(1, 1),\n",
     "    tile_partitioner=communicator.partitioner.tile,\n",
     "    tile_rank=communicator.tile.rank,\n",
-    "    backend=backend\n",
+    "    backend=backend,\n",
     ")\n",
     "quantity_factory = QuantityFactory(sizer, backend=backend)"
    ]
@@ -169,8 +177,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1,:-1]\n",
-    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1,:-1]"
+    "grid_data.lon_agrid.field[:] = grid_data.lon.field[:-1, :-1]\n",
+    "grid_data.lat_agrid.field[:] = grid_data.lat.field[:-1, :-1]"
    ]
   },
   {
@@ -182,8 +190,8 @@
    "source": [
     "conf = PhysicsConfig\n",
     "radconf = RTE_RRTMGPConfig(\n",
-    "    deltsw = 3600.0,\n",
-    "    delt_rad = 3600.0,\n",
+    "    deltsw=3600.0,\n",
+    "    delt_rad=3600.0,\n",
     "    date=date,\n",
     "    fhswr=1.0,\n",
     "    fhlwr=1.0,\n",
@@ -255,7 +263,14 @@
     }
    ],
    "source": [
-    "rad = RTE_RRTMGPDriver(config=radconf, gridlon=gridlon, gridlat=gridlat, sigma=sigma[::-1], quantity_factory=quantity_factory, stencil_factory=stencil_factory)"
+    "rad = RTE_RRTMGPDriver(\n",
+    "    config=radconf,\n",
+    "    gridlon=gridlon,\n",
+    "    gridlat=gridlat,\n",
+    "    sigma=sigma[::-1],\n",
+    "    quantity_factory=quantity_factory,\n",
+    "    stencil_factory=stencil_factory,\n",
+    ")"
    ]
   },
   {
@@ -288,23 +303,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prsi = ds.prsi.values[3:-4,3:-4,::-1] # level pressure\n",
-    "prsl = (prsi[:,:,1:] - prsi[:,:,:-1]) / np.log(prsi[:,:,1:] / prsi[:,:,:-1])\n",
-    "pt = ds.pt.values[3:-4,3:-4,-2::-1] # Layer temperature\n",
-    "delp = ds.delp.values[3:-4,3:-4,-2::-1]\n",
-    "delz = -1.* ds.delz.values[3:-4,3:-4,-2::-1]\n",
-    "dz = -1.* ds.dz.values[3:-4,3:-4,-2::-1]\n",
-    "qvap = ds.qvapor.values[3:-4,3:-4,-2::-1]\n",
-    "qliq = ds.qliquid.values[3:-4,3:-4,-2::-1]\n",
-    "qice = ds.qice.values[3:-4,3:-4,-2::-1]\n",
-    "qcld = ds.qcld.values[3:-4,3:-4,-2::-1]\n",
-    "phii = ds.phii.values[3:-4,3:-4,::-1]\n",
+    "prsi = ds.prsi.values[3:-4, 3:-4, ::-1]  # level pressure\n",
+    "prsl = (prsi[:, :, 1:] - prsi[:, :, :-1]) / np.log(prsi[:, :, 1:] / prsi[:, :, :-1])\n",
+    "pt = ds.pt.values[3:-4, 3:-4, -2::-1]  # Layer temperature\n",
+    "delp = ds.delp.values[3:-4, 3:-4, -2::-1]\n",
+    "delz = -1.0 * ds.delz.values[3:-4, 3:-4, -2::-1]\n",
+    "dz = -1.0 * ds.dz.values[3:-4, 3:-4, -2::-1]\n",
+    "qvap = ds.qvapor.values[3:-4, 3:-4, -2::-1]\n",
+    "qliq = ds.qliquid.values[3:-4, 3:-4, -2::-1]\n",
+    "qice = ds.qice.values[3:-4, 3:-4, -2::-1]\n",
+    "qcld = ds.qcld.values[3:-4, 3:-4, -2::-1]\n",
+    "phii = ds.phii.values[3:-4, 3:-4, ::-1]\n",
     "ptlev = np.zeros_like(prsi)\n",
-    "ptlev[:,:,1:-1] = pt[:,:,:-1] + (pt[:,:,1:] - pt[:,:,:-1]) * (np.log(prsi[:,:,1:-1]) - np.log(prsl[:,:,:-1])) / (np.log(prsl[:,:,1:]) - np.log(prsl[:,:,:-1]))\n",
-    "ptlev[:,:,-1] = pt[:,:,-1]\n",
-    "ptlev[:,:,0] = pt[:,:,0]\n",
-    "qo3mr = ds.qo3mr.values[3:-4,3:-4,-2::-1]\n",
-    "tskin = ptlev[:,:,-1]"
+    "ptlev[:, :, 1:-1] = pt[:, :, :-1] + (pt[:, :, 1:] - pt[:, :, :-1]) * (\n",
+    "    np.log(prsi[:, :, 1:-1]) - np.log(prsl[:, :, :-1])\n",
+    ") / (np.log(prsl[:, :, 1:]) - np.log(prsl[:, :, :-1]))\n",
+    "ptlev[:, :, -1] = pt[:, :, -1]\n",
+    "ptlev[:, :, 0] = pt[:, :, 0]\n",
+    "qo3mr = ds.qo3mr.values[3:-4, 3:-4, -2::-1]\n",
+    "tskin = ptlev[:, :, -1]"
    ]
   },
   {
@@ -353,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "levels = np.arange(nz+1)"
+    "levels = np.arange(nz + 1)"
    ]
   },
   {
@@ -384,10 +401,10 @@
     }
    ],
    "source": [
-    "plt.plot(state.fswd.view[0,0,:], levels, label=\"SW all-sky flux Down\")\n",
-    "plt.plot(state.fswu.view[0,0,:], levels, label=\"SW all-sky flux Up\")\n",
-    "plt.plot(state.flwd.view[0,0,:], levels, label=\"LW all-sky flux Down\")\n",
-    "plt.plot(state.flwu.view[0,0,:], levels, label=\"LW all-sky flux Up\")\n",
+    "plt.plot(state.fswd.view[0, 0, :], levels, label=\"SW all-sky flux Down\")\n",
+    "plt.plot(state.fswu.view[0, 0, :], levels, label=\"SW all-sky flux Up\")\n",
+    "plt.plot(state.flwd.view[0, 0, :], levels, label=\"LW all-sky flux Down\")\n",
+    "plt.plot(state.flwu.view[0, 0, :], levels, label=\"LW all-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },
@@ -449,10 +466,10 @@
     }
    ],
    "source": [
-    "plt.plot(state.fswd.view[0,0,:], levels, label=\"SW all-sky flux Down\")\n",
-    "plt.plot(state.fswu.view[0,0,:], levels, label=\"SW all-sky flux Up\")\n",
-    "plt.plot(state.flwd.view[0,0,:], levels, label=\"LW all-sky flux Down\")\n",
-    "plt.plot(state.flwu.view[0,0,:], levels, label=\"LW all-sky flux Up\")\n",
+    "plt.plot(state.fswd.view[0, 0, :], levels, label=\"SW all-sky flux Down\")\n",
+    "plt.plot(state.fswu.view[0, 0, :], levels, label=\"SW all-sky flux Up\")\n",
+    "plt.plot(state.flwd.view[0, 0, :], levels, label=\"LW all-sky flux Down\")\n",
+    "plt.plot(state.flwu.view[0, 0, :], levels, label=\"LW all-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },
@@ -537,10 +554,10 @@
     }
    ],
    "source": [
-    "plt.plot(state.fswd.view[0,0,:], levels, label=\"SW all-sky flux Down\")\n",
-    "plt.plot(state.fswu.view[0,0,:], levels, label=\"SW all-sky flux Up\")\n",
-    "plt.plot(state.flwd.view[0,0,:], levels, label=\"LW all-sky flux Down\")\n",
-    "plt.plot(state.flwu.view[0,0,:], levels, label=\"LW all-sky flux Up\")\n",
+    "plt.plot(state.fswd.view[0, 0, :], levels, label=\"SW all-sky flux Down\")\n",
+    "plt.plot(state.fswu.view[0, 0, :], levels, label=\"SW all-sky flux Up\")\n",
+    "plt.plot(state.flwd.view[0, 0, :], levels, label=\"LW all-sky flux Down\")\n",
+    "plt.plot(state.flwu.view[0, 0, :], levels, label=\"LW all-sky flux Up\")\n",
     "plt.legend(frameon=False)"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
   "f90nml>=1.1.0",
@@ -54,8 +55,7 @@ Repository = "https://github.com/NOAA-GFDL/PySHiELD"
 [tool.aliases]
 
 [tool.black]
-line-length = 88
-target_version = ['py311']
+target-version = ["py311", "py312", "py313"]
 
 [tool.coverage.run]
 branch = true
@@ -76,15 +76,10 @@ max-line-length = 88
 
 [tool.isort]
 default_section = "THIRDPARTY"
-force_grid_wrap = 0
-include_trailing_comma = true
 known_first_party = "pyfv3,ndsl,pyshield"
 known_third_party = "f90nml,pytest,xarray,numpy,mpi4py,gt4py"
-line_length = 88
-lines_after_imports = 2
-multi_line_output = 3
+profile = "black"
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
-use_parentheses = true
 
 [tool.mypy]
 explicit_package_bases = true

--- a/pyshield/__init__.py
+++ b/pyshield/__init__.py
@@ -3,7 +3,6 @@ from .physics_state import PhysicsState
 from .stencils.physics import Physics
 from .stencils.surface import SurfaceState
 
-
 __all__ = [
     "PHYSICS_PACKAGES",
     "PhysicsConfig",

--- a/pyshield/_config.py
+++ b/pyshield/_config.py
@@ -13,7 +13,6 @@ from ndsl.dsl.typing import Float, set_4d_field_size
 from ndsl.utils import f90nml_as_dict
 from pyshield.tracer_workarounds import tracer_variables
 
-
 # TODO: This will become a TracerBundle when ready
 FloatFieldTracer = set_4d_field_size(9, Float)
 

--- a/pyshield/constants.py
+++ b/pyshield/constants.py
@@ -1,7 +1,6 @@
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float
 
-
 # Driver constants
 HOCP = Float(constants.HLV / constants.CP_AIR)
 QMIN = Float(1.0e-10)

--- a/pyshield/functions/microphysics_funcs.py
+++ b/pyshield/functions/microphysics_funcs.py
@@ -3,7 +3,6 @@ from ndsl.dsl.gt4py import exp
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import log, sqrt
 
-
 # Marshall-Palmer constants ###
 VCONS = 6.6280504
 VCONG = 87.2382675

--- a/pyshield/radiation/__init__.py
+++ b/pyshield/radiation/__init__.py
@@ -2,7 +2,6 @@ from ._config import RTE_RRTMGPConfig
 from .rte_rrtmgp import RTE_RRTMGPDriver
 from .state import RTE_RRTMGPState
 
-
 """
 RTE_RRTMGPConfig: Configuration class for the radiation driver
 RTE_RRTMGPDriver: Driver for the RTE_RRTMGP code

--- a/pyshield/radiation/rad_astro.py
+++ b/pyshield/radiation/rad_astro.py
@@ -9,7 +9,6 @@ from ndsl.dsl.gt4py import FORWARD, acos, computation, cos, interval, sin
 from ndsl.dsl.typing import BoolFieldIJ, Float, FloatFieldIJ, Int
 from ndsl.logging import ndsl_log
 
-
 CCR = Float(1.3e-6)  # iteration limit
 CYEAR = Float(365.25)  # days of year
 SVT6 = Float(78.035)  # days between perihelion passage and march equinox of 1900

--- a/pyshield/radiation/rad_clouds.py
+++ b/pyshield/radiation/rad_clouds.py
@@ -2,7 +2,6 @@ import ndsl.constants as constants
 from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, IntFieldIJ
 
-
 RE_LIQ = 10.0
 """Default liquid radius in microns"""
 RE_ICE = 50.0

--- a/pyshield/radiation/rad_gases.py
+++ b/pyshield/radiation/rad_gases.py
@@ -9,7 +9,6 @@ from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, Int
 from ndsl.logging import ndsl_log
 
-
 NDAYS_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 30]
 MINYEAR = 1957  # earliest year 2-d co2 data available
 NF_VGAS = 10  # number of gas species

--- a/pyshield/radiation/rad_sfc.py
+++ b/pyshield/radiation/rad_sfc.py
@@ -7,7 +7,6 @@ import pyshield.constants as physcons
 from ndsl.dsl.typing import Float, Int
 from ndsl.logging import ndsl_log
 
-
 LAND_ALBEDO = 0.25
 OCEAN_ALBEDO = 0.06
 ICE_ALBEDO = 0.65

--- a/pyshield/radiation/rte_rrtmgp.py
+++ b/pyshield/radiation/rte_rrtmgp.py
@@ -23,7 +23,6 @@ from .rad_gases import co2_update, gas_init, get_gases_bottomup, get_gases_topdo
 from .rad_sfc import set_albedo, set_sfcemis, sfc_init
 from .state import RTE_RRTMGPState
 
-
 GRAV = 9.80665
 CP_DRY = 1004.64
 QMIN = 1.0e-10

--- a/pyshield/radiation/state.py
+++ b/pyshield/radiation/state.py
@@ -386,7 +386,7 @@ class RTE_RRTMGPState:
                             newshape = (-1,)  # type: ignore[assignment]
                             dims.insert(0, "column")
                         elif ndims == 1:  # z-array
-                            newshape == (nz,)
+                            newshape = (nz,)  # type: ignore[assignment]
                         else:
                             raise NotImplementedError(
                                 (

--- a/pyshield/stencils/__init__.py
+++ b/pyshield/stencils/__init__.py
@@ -1,6 +1,5 @@
 from .gfs_microphysics import GFSMicrophysics, GFSMicrophysicsState
 
-
 """
 GFSMicrophysics: GFS Cloud Microphysics class
 GFSMicrophysicsState: Class containing the state for the GFS Cloud Microphysics

--- a/pyshield/stencils/gfdl_cld_microphysics/__init__.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/__init__.py
@@ -2,7 +2,6 @@ from ._config import GFDLCloudMPConfig
 from .gfdl_cld_microphysics_state import GFDLCloudMicrophysicsState
 from .gfdl_cld_mp_driver import GFDLCloudMicrophysics
 
-
 """
 GFDLCloudMicrophysics: GFDL Cloud Microphysics class
 GFDLCloudMicrophysicsState: Class containing the state for the GFDL Cloud Microphysics

--- a/pyshield/stencils/gfdl_cld_microphysics/_config.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/_config.py
@@ -5,7 +5,6 @@ from typing import List, Tuple
 import ndsl.constants as constants
 import pyshield.stencils.gfdl_cld_microphysics.constants as mpcons
 
-
 DEFAULT_INT = 0
 DEFAULT_FLOAT = 0.0
 DEFAULT_STR = ""

--- a/pyshield/stencils/gfdl_cld_microphysics/constants.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/constants.py
@@ -3,7 +3,6 @@ import math
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float
 
-
 # Constant parameters used in the GFDL Cloud Microphysics
 TICE0 = Float(constants.TICE - 0.01)
 

--- a/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/gfdl_cld_mp_driver.py
@@ -1170,8 +1170,10 @@ class GFDLCloudMicrophysics:
         self,
         state: GFDLCloudMicrophysicsState,
         last_step: Bool = True,
-        timer: Timer = NullTimer(),
+        timer: Timer | None = None,
     ):
+        if timer is None:
+            timer = NullTimer()
 
         self._reset_initial_values_and_make_copies(
             state.adj_vmr,

--- a/pyshield/stencils/gfdl_cld_microphysics/ice_cloud.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/ice_cloud.py
@@ -1197,7 +1197,7 @@ def ice_cloud(
             vterminal_s,
         )
 
-        (qice, qsnow, di, temperature) = autoconvert_ice_to_snow(
+        qice, qsnow, di, temperature = autoconvert_ice_to_snow(
             qice, qsnow, temperature, density, di
         )
 

--- a/pyshield/stencils/gfdl_cld_microphysics/mp_full.py
+++ b/pyshield/stencils/gfdl_cld_microphysics/mp_full.py
@@ -190,7 +190,7 @@ class FullMicrophysics:
         Full Microphysics Loop
         executes ntimes:
         """
-        for i in range(self._ntimes):
+        for _i in range(self._ntimes):
             self._sedimentation(
                 qvapor,
                 qliquid,

--- a/pyshield/stencils/pbl/__init__.py
+++ b/pyshield/stencils/pbl/__init__.py
@@ -2,7 +2,6 @@ from ._config import PBLConfig
 from .satmedmfvdiff import ScaleAwareTKEMoistEDMF
 from .satmedmfvdiff_state import SATMEDMFVDiffState
 
-
 """
 PBLConfig: Configuration settings for PBL scheme
 ScaleAwareTKEMoistEDMF: GFS scale aware turbulent moist edmf scheme, satmedmfvdif

--- a/pyshield/stencils/pbl/_config.py
+++ b/pyshield/stencils/pbl/_config.py
@@ -2,7 +2,6 @@ import dataclasses
 
 from pyshield.tracer_workarounds import tracer_variables
 
-
 DEFAULT_INT = 0
 DEFAULT_FLOAT = 0.0
 DEFAULT_BOOL = False

--- a/pyshield/stencils/pbl/constants.py
+++ b/pyshield/stencils/pbl/constants.py
@@ -1,7 +1,6 @@
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float
 
-
 # Constants used for turbulence schemes
 A1 = Float(0.12)
 A2 = Float(0.5)

--- a/pyshield/stencils/pbl/mfpblt.py
+++ b/pyshield/stencils/pbl/mfpblt.py
@@ -19,7 +19,6 @@ from ndsl.initialization.allocator import QuantityFactory
 from pyshield._config import FloatFieldTracer
 from pyshield.functions.physics_functions import fpvs
 
-
 A1 = 0.13
 
 

--- a/pyshield/stencils/shallow_convection/__init__.py
+++ b/pyshield/stencils/shallow_convection/__init__.py
@@ -2,7 +2,6 @@ from ._config import ShallowConvectionConfig
 from .samf_shalconv_state import SAMFShalConvState
 from .samfshalconv import ScaleAwareMassFluxShallowConvection
 
-
 """
 ShallowConvectionConfig: Configuration class for the shallow convection
 ScaleAwareMassFluxShallowConvection: Shallow convection class

--- a/pyshield/stencils/shallow_convection/_config.py
+++ b/pyshield/stencils/shallow_convection/_config.py
@@ -2,7 +2,6 @@ import dataclasses
 
 from pyshield.tracer_workarounds import tracer_variables
 
-
 _DEFAULT_INT = 0
 DEFAULT_BOOL = False
 DEFAULT_FLOAT = 0.0

--- a/pyshield/stencils/shallow_convection/constants.py
+++ b/pyshield/stencils/shallow_convection/constants.py
@@ -1,6 +1,5 @@
 from ndsl.dsl.typing import Float
 
-
 # Constants used in the shallow convection scheme
 CM = Float(1.0)
 CLAMD = Float(0.1)

--- a/pyshield/stencils/surface/__init__.py
+++ b/pyshield/stencils/surface/__init__.py
@@ -2,7 +2,6 @@ from ._config import SurfaceConfig
 from .sfc_state import SurfaceState
 from .surface_layer import SurfaceLayer
 
-
 """
 "SurfaceConfig": Class containing configuration settings for the surface physics
 SurfaceLayer: Surface physics class

--- a/pyshield/stencils/surface/_config.py
+++ b/pyshield/stencils/surface/_config.py
@@ -1,7 +1,6 @@
 import dataclasses
 from typing import Sequence
 
-
 DEFAULT_FLOAT = 0.0
 DEFAULT_INT = 0
 DEFAULT_BOOL = False

--- a/pyshield/stencils/surface/constants.py
+++ b/pyshield/stencils/surface/constants.py
@@ -1,7 +1,6 @@
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float
 
-
 # sfc_sice constants
 FLOAT_EPS = Float(1.0e-8)
 HIMAX = Float(8.0)

--- a/pyshield/update/__init__.py
+++ b/pyshield/update/__init__.py
@@ -2,7 +2,6 @@ from .fv_update_phys import ApplyPhysicsToDycore
 from .update_atmos_state import DycoreToPhysics, UpdateAtmosphereState
 from .update_dwind_phys import AGrid2DGridPhysics
 
-
 """
 ApplyPhysicsToDycore: Class to update the pyFV3 dynamical core state from the physics
                       state

--- a/pyshield/update/update_atmos_state.py
+++ b/pyshield/update/update_atmos_state.py
@@ -10,7 +10,6 @@ from ndsl.typing import Communicator
 from pyfv3.stencils import fv_subgridz
 from pyshield.update.fv_update_phys import ApplyPhysicsToDycore
 
-
 # TODO: when this file is not importable from physics or pyFV3, import
 #       PhysicsState and DycoreState and use them to type hint below
 

--- a/tests/savepoint/conftest.py
+++ b/tests/savepoint/conftest.py
@@ -7,5 +7,4 @@ from ndsl.stencils.testing.conftest import *  # noqa: F403,F401
 
 from . import translate
 
-
 ndsl.stencils.testing.conftest.translate = translate  # type: ignore

--- a/tests/savepoint/translate/translate_cumulative_shalconv.py
+++ b/tests/savepoint/translate/translate_cumulative_shalconv.py
@@ -45,7 +45,6 @@ from pyshield.stencils.shallow_convection.samfshalconv import (
 )
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
 
-
 FloatFieldShalConv = set_4d_field_size(7, Float)
 
 SC_TRACER_DIM = "n_tracers_shal"

--- a/tests/savepoint/translate/translate_fv_update_phys.py
+++ b/tests/savepoint/translate/translate_fv_update_phys.py
@@ -15,7 +15,6 @@ from tests.savepoint.translate.translate_physics import (
     transform_dwind_serialized_data,
 )
 
-
 try:
     import cupy as cp
 except ImportError:

--- a/tests/savepoint/translate/translate_mp_full.py
+++ b/tests/savepoint/translate/translate_mp_full.py
@@ -133,7 +133,7 @@ class SubMicrophysics:
         Full Microphysics Loop
         executes ntimes:
         """
-        for i in range(self._ntimes):
+        for _i in range(self._ntimes):
             # self._sedimentation(
             #     qvapor,
             #     qliquid,

--- a/tests/savepoint/translate/translate_samfshalconv.py
+++ b/tests/savepoint/translate/translate_samfshalconv.py
@@ -10,7 +10,6 @@ from pyshield.stencils.shallow_convection import (
 )
 from tests.savepoint.translate.translate_physics import TranslatePhysicsFortranData2Py
 
-
 FloatFieldShalConv = set_4d_field_size(7, Float)
 
 SC_TRACER_DIM = "n_tracers_shal"


### PR DESCRIPTION
**Description**

We haven't updated our linting tools in a long-ish time. In particular, `isort`  was pointing to a repo that is archived by now. List of updates:

- black: 25.1.0 -> 26.5.1
- isort: 5.10.1 -> 8.0.1
- mypy: 1.17.0 -> 2.3.0
- pre-commit hooks: 5.0.0 -> 6.0.0
- yaml/toml formatter: 2.15.0 -> 2.16.0

**How Has This Been Tested?**

All good as long as CI is green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model, if this change was triggered by a model need/shortcoming: N/A
